### PR TITLE
feat: 보안 및 유저 개인 정보 보호를 위한 헤더 재조정

### DIFF
--- a/.vscode/article.code-snippets
+++ b/.vscode/article.code-snippets
@@ -1,0 +1,35 @@
+{
+  "Post Matter": {
+    "prefix": ["matter", "---"],
+    "description": "set post matter",
+    "body": [
+      "---",
+      "title: '$1'",
+      "publishedAt: '$CURRENT_YEAR-$CURRENT_MONTH-$CURRENT_DATE'",
+      "category: ''",
+      "summary: ''",
+      "image: ''",
+      "---",
+      "",
+      "$0"
+    ],
+    "scope": "md,mdx"
+  },
+  "Video Embed": {
+    "prefix": ["video", "embed"],
+    "description": "embed video",
+    "body": [
+      "<video",
+      "  width='100%'",
+      "  controls",
+      "  preload='metadata'",
+      "  muted",
+      "  playsinline",
+      ">",
+      "  <source src='/videos/$1' type='video/mp4' />",
+      "  Your browser does not support the video tag.",
+      "</video>"
+    ],
+    "scope": "md,mdx"
+  },  
+}

--- a/.vscode/article.code-snippets
+++ b/.vscode/article.code-snippets
@@ -24,7 +24,7 @@
       "  controls",
       "  preload='metadata'",
       "  muted",
-      "  playsinline",
+      "  playsInline",
       ">",
       "  <source src='/videos/$1' type='video/mp4' />",
       "  Your browser does not support the video tag.",

--- a/lint-staged.config.js
+++ b/lint-staged.config.js
@@ -1,3 +1,5 @@
 module.exports = {
-  '*.{js,jsx,ts,tsx}': ['eslint --fix'],
+  '*.{js,jsx,ts,tsx}': ['eslint --fix', 'prettier --write'],
+  '**/*.ts?(x)': () => 'pnpm check-types',
+  '*.{md,mdx}': ['prettier --write'],
 };

--- a/lint-staged.config.js
+++ b/lint-staged.config.js
@@ -1,5 +1,3 @@
 module.exports = {
-  '*.{js,jsx,ts,tsx}': ['eslint --fix', 'prettier --write'],
-  '**/*.ts?(x)': () => 'pnpm check-types',
-  '*.{md,mdx}': ['prettier --write'],
+  '*.{js,jsx,ts,tsx}': ['eslint --fix'],
 };

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -5,6 +5,62 @@ const bundleAnalyzer = withBundleAnalyzer({
 });
 
 /** @type {import('next').NextConfig} */
-const nextConfig = {};
+const nextConfig = {
+  logging: {
+    fetches: {
+      fullUrl: true,
+    },
+  },
+  headers() {
+    return [
+      {
+        source: '/(.*)',
+        headers: securityHeaders,
+      },
+    ];
+  },
+};
+
+const ContentSecurityPolicy = `
+    default-src 'self' vercel.live;
+    script-src 'self' 'unsafe-eval' 'unsafe-inline' cdn.vercel-insights.com vercel.live va.vercel-scripts.com;
+    style-src 'self' 'unsafe-inline';
+    img-src * blob: data:;
+    media-src 'self';
+    connect-src *;
+    font-src 'self' data:;
+    frame-src 'self' *.codesandbox.io vercel.live;
+`;
+
+const securityHeaders = [
+  {
+    key: 'Content-Security-Policy',
+    value: ContentSecurityPolicy.replace(/\n/g, ''),
+  },
+  {
+    key: 'Referrer-Policy',
+    value: 'origin-when-cross-origin',
+  },
+  {
+    key: 'X-Frame-Options',
+    value: 'DENY',
+  },
+  {
+    key: 'X-Content-Type-Options',
+    value: 'nosniff',
+  },
+  {
+    key: 'X-DNS-Prefetch-Control',
+    value: 'on',
+  },
+  {
+    key: 'Strict-Transport-Security',
+    value: 'max-age=31536000; includeSubDomains; preload',
+  },
+  {
+    key: 'Permissions-Policy',
+    value: 'camera=(), microphone=(), geolocation=()',
+  },
+];
 
 export default bundleAnalyzer(nextConfig);

--- a/src/app/api/og/route.tsx
+++ b/src/app/api/og/route.tsx
@@ -11,12 +11,8 @@ const interSemiBold = fetch(
 
 export async function GET(req: NextRequest): Promise<Response | ImageResponse> {
   try {
-    const { searchParams } = new URL(req.url);
     const isLight = req.headers.get('Sec-CH-Prefers-Color-Scheme') === 'light';
-
-    const title = searchParams.has('title')
-      ? searchParams.get('title')
-      : siteMetadata.title;
+    const title = siteMetadata.title;
 
     return new ImageResponse(
       (

--- a/src/app/article/[slug]/page.tsx
+++ b/src/app/article/[slug]/page.tsx
@@ -2,6 +2,7 @@ import { notFound } from 'next/navigation';
 
 import { formatDate, getArticles } from '@/app/article/utils';
 import { CustomMDX } from '@/components/mdx';
+import { isEmptyString } from '@/lib/assertions';
 import { siteMetadata } from '@/lib/site-metadata';
 
 export async function generateStaticParams() {
@@ -14,8 +15,9 @@ export async function generateStaticParams() {
 
 export function generateMetadata({ params }: { params: { slug: string } }) {
   const post = getArticles().find(post => post.slug === params.slug);
+
   if (!post) {
-    return;
+    notFound();
   }
 
   const {
@@ -25,9 +27,9 @@ export function generateMetadata({ params }: { params: { slug: string } }) {
     image,
   } = post.metadata;
   const title = `${postTitle} • ${siteMetadata.title} article`;
-  const ogImage = image
-    ? image
-    : `/api/og?title=${encodeURIComponent(postTitle)}`;
+  const ogImage = isEmptyString(image)
+    ? `/api/og?title=${encodeURIComponent(postTitle)}`
+    : image!;
 
   return {
     title,
@@ -75,7 +77,7 @@ export default function Blog({ params }: { params: { slug: string } }) {
             description: post.metadata.summary,
             image: post.metadata.image
               ? `${siteMetadata.siteUrl}${post.metadata.image}`
-              : `/og?title=${encodeURIComponent(post.metadata.title)}`,
+              : `/api/og?title=${encodeURIComponent(post.metadata.title)}`,
             url: `${siteMetadata.siteUrl}/article/${post.slug}`,
             author: {
               '@type': 'Person',

--- a/src/app/article/articles/react/immediate-motion-component.mdx
+++ b/src/app/article/articles/react/immediate-motion-component.mdx
@@ -226,7 +226,7 @@ if (isValidElement(child) && Symbol('motionComponentSymbol')) {...}
   controls
   preload="metadata"
   muted
-  playsinline
+  playsInline
 >
   <source src="/videos/usage-motion-slot.mp4" type="video/mp4" />
   Your browser does not support the video tag.

--- a/src/app/article/articles/react/immediate-motion-component.mdx
+++ b/src/app/article/articles/react/immediate-motion-component.mdx
@@ -225,9 +225,8 @@ if (isValidElement(child) && Symbol('motionComponentSymbol')) {...}
   width="100%"
   controls
   preload="metadata"
-  autoPlay={false}
   muted
-  playsInline
+  playsinline
 >
   <source src="/videos/usage-motion-slot.mp4" type="video/mp4" />
   Your browser does not support the video tag.

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -53,7 +53,7 @@ export default function RootLayout({
             {children}
             <footer
               aria-labelledby="footer-navigation"
-              className="bd-fixed bd-bottom-2 bd-left-1/2 bd-z-10 bd-flex bd-h-14 bd-w-4/5 -bd-translate-x-1/2 -bd-translate-y-1/2 bd-transform bd-items-end bd-rounded-full bd-border bd-border-solid bd-border-input bd-bg-gray-100 bd-px-2 bd-shadow-sm bd-shadow-secondary sm:bd-w-auto"
+              className="bd-fixed -bd-bottom-2 bd-left-1/2 bd-z-10 bd-flex bd-h-14 bd-w-4/5 -bd-translate-x-1/2 -bd-translate-y-1/2 bd-transform bd-items-end bd-rounded-full bd-border bd-border-solid bd-border-input bd-bg-gray-100 bd-px-2 bd-shadow-sm bd-shadow-secondary sm:bd-w-auto"
             >
               <h2 id="footer-navigation" className="bd-sr-only">
                 Footer navigation

--- a/src/components/navigation/model/use-navigation-item-animation.ts
+++ b/src/components/navigation/model/use-navigation-item-animation.ts
@@ -42,7 +42,7 @@ export const useNavigationItemAnimation = ({
   );
   const width = useSpring(widthSync, {
     mass: 0.1,
-    stiffness: 150,
+    stiffness: 140,
     damping: 12,
   });
 

--- a/src/lib/assertions.ts
+++ b/src/lib/assertions.ts
@@ -1,0 +1,2 @@
+export const isEmptyString = (str: string | undefined): boolean =>
+  str?.trim().length === 0;


### PR DESCRIPTION
## 요약

Next.js 헤더 설정

주요 목표는 허용된 도메인에서 받은 소스 파일에서 로드된 스크립트만 실행하도록 설정하기 위함입니다. 보안 및 사용자의 개인 정보 보호를 위한 작업이 포함되어 있습니다.

1. **Content-Security-Policy**: 웹 페이지에서 사용할 수 있는 리소스의 종류와 출처를 제한합니다. 주로 XSS 공격을 방지하기 위함입니다. Chrome 웹 익스텐션에서 HMR을 적용하기 힘든 이유기도 했습니다.😂 미디어 파일, css 파일 등은 자신의 도메인에서 로드할 수 있도록 설정했고 예외로 스크립트 파일의 경우엔 배포를 위한 [vercel.live](https://vercel.com/products/previews)에서 호스팅되는 리소스도 다운 받을 수 있도록 설정해두었습니다.
2. **Referrer-Policy:** 브라우저가 다른 도메인으로 요청을 수행할 때, HTTP Referrer 헤더를 어떻게 보낼지를 결정합니다. `origin-when-cross-origin` 옵션은 동일 출처 요청에는 전체 URL(origin, path, query string)을, 다른 출처 요청에는 origin만을 보냅니다.
3. **X-Frame-Options**: 특정 페이지를 `<frame>`, `<iframe>`, `<embed>`, 또는 `<object>` 내에서 렌더링되는 것을 방지합니다. DENY는 모든 도메인에서의 프레이밍을 금지합니다. 즉, 어떠한 사이트에서도 frame 상에서 보여질 수 없습니다.
4. **X-Content-Type-Options**: 브라우저가 MIME 타입을 추측(sniffing)하지 않도록 합니다. `nosniff`를 설정하면 서버가 명시적으로 선언하지 않은 style/script의 실행을 방지하여 보안을 강화합니다. 사이트 보안 테스터는 일반적으로 이 헤더가 설정되어 있을 것으로 예상한다고 합니다.
5. **X-DNS-Prefetch-Control**: 브라우저가 페이지에 링크된 도메인의 DNS 요청을 미리 수행할지 여부를 제어합니다. `on`으로 설정하면 성능 향상을 위해 `DNS-prefetching`이 활성화되고, 사용자가 링크를 클릭할 때와 같은 특정 시점에 지연 시간을 크게 줄일 수 있습니다. 단, 비표준 기능이며 모든 사용자에 대해 작동하지는 않습니다.
6. **Strict-Transport-Security**: HTTPS를 통한 접속만을 허용하고, 일정 기간 동안 (설정한 값은 1년) HTTP로의 접속 시도를 자동으로 HTTPS로 리다이렉트합니다. `includeSubDomains`는 모든 서브 도메인에도 같은 정책을 적용하고, `preload`는 브라우저의 [HSTS preload list](https://hstspreload.org/)에 사이트를 등록할 수 있도록 합니다.
7. **Permissions-Policy**: 특정 웹 API의 사용을 제한합니다. 사용자의 개인 정보 보호를 위해 카메라, 마이크, 위치 정보의 사용을 금지하도록 설정해두었습니다.

## 참고

- https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers
- https://nextjs.org/docs/app/api-reference/next-config-js/headers#strict-transport-security