### PR TITLE
feat(seo): Google Sitelinks 개선을 위한 JSON-LD 구조화 데이터 추가

### DIFF
--- a/src/app/article/page.tsx
+++ b/src/app/article/page.tsx
@@ -1,7 +1,9 @@
 import type { Metadata, ResolvingMetadata } from 'next';
+import type { CollectionPage, WithContext } from 'schema-dts';
 
 import { ArticleList } from '@/components/article';
 import { siteMetadata } from '@/lib/site-metadata';
+import { readArticles, sortByDateDesc } from '@/mdx/mdx';
 
 export async function generateMetadata(
   {},
@@ -29,8 +31,34 @@ export async function generateMetadata(
 }
 
 export default function ArticlePage() {
+  const articles = sortByDateDesc(readArticles());
+
+  const collectionJsonLd: WithContext<CollectionPage> = {
+    '@context': 'https://schema.org',
+    '@type': 'CollectionPage',
+    name: '기술 이야기',
+    description: '경험과 지식을 공유하는 공간입니다.',
+    url: `${siteMetadata.siteUrl}/article`,
+    mainEntity: {
+      '@type': 'ItemList',
+      itemListElement: articles.map((article, index) => ({
+        '@type': 'ListItem' as const,
+        position: index + 1,
+        url: `${siteMetadata.siteUrl}/article/${article.slug}`,
+        name: article.metadata.title,
+      })),
+    },
+  };
+
   return (
     <main>
+      <script
+        type="application/ld+json"
+        suppressHydrationWarning
+        dangerouslySetInnerHTML={{
+          __html: JSON.stringify(collectionJsonLd),
+        }}
+      />
       <ArticleList />
     </main>
   );

--- a/src/app/article/series/[id]/page.tsx
+++ b/src/app/article/series/[id]/page.tsx
@@ -1,13 +1,13 @@
 import type { Metadata } from 'next';
 import Link from 'next/link';
 import { notFound } from 'next/navigation';
+import { cache } from 'react';
+import type { CollectionPage, WithContext } from 'schema-dts';
 
 import { Typography } from '@/components/ui/typography';
 import { getAllSeriesIds, getSeriesConfig } from '@/lib/series';
 import { siteMetadata } from '@/lib/site-metadata';
 import { cn } from '@/lib/utils';
-import { cache } from 'react';
-
 import { formatDate, getSeriesInfo, readArticles } from '@/mdx/mdx';
 
 const getArticles = cache(() => readArticles());
@@ -51,8 +51,32 @@ export default function SeriesPage({
   const seriesInfo = getSeriesInfo(articles, params.id, -1);
   if (!seriesInfo) notFound();
 
+  const collectionJsonLd: WithContext<CollectionPage> = {
+    '@context': 'https://schema.org',
+    '@type': 'CollectionPage',
+    name: `${config.name} 시리즈`,
+    description: config.description,
+    url: `${siteMetadata.siteUrl}/article/series/${params.id}`,
+    mainEntity: {
+      '@type': 'ItemList',
+      itemListElement: seriesInfo.articles.map((article, index) => ({
+        '@type': 'ListItem' as const,
+        position: index + 1,
+        url: `${siteMetadata.siteUrl}/article/${article.slug}`,
+        name: article.title,
+      })),
+    },
+  };
+
   return (
     <main className="relative mx-auto my-0 min-h-screen max-w-2xl overflow-hidden px-6 py-32">
+      <script
+        type="application/ld+json"
+        suppressHydrationWarning
+        dangerouslySetInnerHTML={{
+          __html: JSON.stringify(collectionJsonLd),
+        }}
+      />
       <Typography variant="h2">{config.name} 시리즈</Typography>
       <Typography variant="p" className="!mt-2 text-muted-foreground">
         {config.description}

--- a/src/app/article/series/[id]/page.tsx
+++ b/src/app/article/series/[id]/page.tsx
@@ -59,9 +59,9 @@ export default function SeriesPage({
     url: `${siteMetadata.siteUrl}/article/series/${params.id}`,
     mainEntity: {
       '@type': 'ItemList',
-      itemListElement: seriesInfo.articles.map((article, index) => ({
+      itemListElement: seriesInfo.articles.map(article => ({
         '@type': 'ListItem' as const,
-        position: index + 1,
+        position: article.order,
         url: `${siteMetadata.siteUrl}/article/${article.slug}`,
         name: article.title,
       })),

--- a/src/app/craft/page.tsx
+++ b/src/app/craft/page.tsx
@@ -1,4 +1,5 @@
 import type { Metadata, ResolvingMetadata } from 'next';
+import type { CollectionPage, WithContext } from 'schema-dts';
 
 import { ArticleItem } from '@/components/article/ui/article-item';
 import { siteMetadata } from '@/lib/site-metadata';
@@ -30,14 +31,37 @@ export async function generateMetadata(
 }
 
 export default function CraftPage() {
-  const articles = readCraftArticles();
-  const formattedArticleInfo = formatCraftsForDisplay(
-    sortByDateDesc(articles),
-    { includeRelativeDate: false }
-  );
+  const articles = sortByDateDesc(readCraftArticles());
+  const formattedArticleInfo = formatCraftsForDisplay(articles, {
+    includeRelativeDate: false,
+  });
+
+  const collectionJsonLd: WithContext<CollectionPage> = {
+    '@context': 'https://schema.org',
+    '@type': 'CollectionPage',
+    name: '작업 목록',
+    description: '작업한 결과물을 모아놓은 공간입니다.',
+    url: `${siteMetadata.siteUrl}/craft`,
+    mainEntity: {
+      '@type': 'ItemList',
+      itemListElement: articles.map((article, index) => ({
+        '@type': 'ListItem' as const,
+        position: index + 1,
+        url: `${siteMetadata.siteUrl}/craft/${article.slug}`,
+        name: article.metadata.title,
+      })),
+    },
+  };
 
   return (
     <main className="relative mx-auto my-0 min-h-screen max-w-4xl overflow-y-auto px-6 pt-10 sm:py-32">
+      <script
+        type="application/ld+json"
+        suppressHydrationWarning
+        dangerouslySetInnerHTML={{
+          __html: JSON.stringify(collectionJsonLd),
+        }}
+      />
       <div className="mt-8 flex flex-col gap-7">
         {formattedArticleInfo.map((article, index) => (
           <ArticleItem key={article.href} {...article} index={index} />

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -3,6 +3,7 @@ import { SpeedInsights } from '@vercel/speed-insights/next';
 import type { Metadata } from 'next';
 import dynamic from 'next/dynamic';
 import { Fira_Mono as FontMono, Inter as FontSans } from 'next/font/google';
+import type { WebSite, WithContext } from 'schema-dts';
 
 import { Navigation } from '@/components/navigation';
 import { ThemeProvider } from '@/components/theme';
@@ -83,6 +84,20 @@ export const metadata = {
   },
 } satisfies Metadata;
 
+const websiteJsonLd: WithContext<WebSite> = {
+  '@context': 'https://schema.org',
+  '@type': 'WebSite',
+  name: `${siteMetadata.author} - 소프트웨어 엔지니어`,
+  url: siteMetadata.siteUrl,
+  description: siteMetadata.description,
+  inLanguage: 'ko',
+  publisher: {
+    '@type': 'Person',
+    name: siteMetadata.author,
+    url: siteMetadata.siteUrl,
+  },
+};
+
 export default function RootLayout({
   children,
 }: Readonly<{
@@ -100,6 +115,13 @@ export default function RootLayout({
       dir="ltr"
     >
       <body className="antialiased">
+        <script
+          type="application/ld+json"
+          suppressHydrationWarning
+          dangerouslySetInnerHTML={{
+            __html: JSON.stringify(websiteJsonLd),
+          }}
+        />
         <BrowserDetector />
         <ThemeProvider
           attribute="class"

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -9,7 +9,7 @@ export const metadata: Metadata = {
     absolute: `${siteMetadata.author} - 소프트웨어 엔지니어`,
   },
   description:
-    '애니메이션과 마이크로 인터랙션으로 유려한 사용자 경험을 만드는 소프트웨어 엔지니어 이재민의 블로그입니다.',
+    '작업하며 마주한 문제와 해결 과정을 정리해 공유합니다. 이 글이 누군가에게 도움이 되길 바랍니다.',
   alternates: {
     canonical: siteMetadata.siteUrl,
   },
@@ -22,7 +22,7 @@ const personJsonLd: WithContext<Person> = {
   url: siteMetadata.siteUrl,
   jobTitle: '소프트웨어 엔지니어',
   description:
-    '애니메이션과 마이크로 인터랙션으로 유려한 사용자 경험을 만드는 소프트웨어 엔지니어',
+    '해야 하는 일 속에서 하고 싶은 의미를 찾는 소프트웨어 엔지니어',
   sameAs: [siteMetadata.github, siteMetadata.youtube],
 };
 

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,8 +1,41 @@
+import type { Metadata } from 'next';
+import type { Person, WithContext } from 'schema-dts';
+
 import { Typography } from '@/components/ui/typography';
+import { siteMetadata } from '@/lib/site-metadata';
+
+export const metadata: Metadata = {
+  title: {
+    absolute: `${siteMetadata.author} - 소프트웨어 엔지니어`,
+  },
+  description:
+    '애니메이션과 마이크로 인터랙션으로 유려한 사용자 경험을 만드는 소프트웨어 엔지니어 이재민의 블로그입니다.',
+  alternates: {
+    canonical: siteMetadata.siteUrl,
+  },
+};
+
+const personJsonLd: WithContext<Person> = {
+  '@context': 'https://schema.org',
+  '@type': 'Person',
+  name: siteMetadata.author,
+  url: siteMetadata.siteUrl,
+  jobTitle: '소프트웨어 엔지니어',
+  description:
+    '애니메이션과 마이크로 인터랙션으로 유려한 사용자 경험을 만드는 소프트웨어 엔지니어',
+  sameAs: [siteMetadata.github, siteMetadata.youtube],
+};
 
 export default function Home() {
   return (
     <div className="relative mx-auto min-h-screen max-w-2xl overflow-hidden px-6 py-24 sm:pb-16 sm:pt-32 ">
+      <script
+        type="application/ld+json"
+        suppressHydrationWarning
+        dangerouslySetInnerHTML={{
+          __html: JSON.stringify(personJsonLd),
+        }}
+      />
       <header className="mb-32 flex flex-col">
         <Typography variant="h5" asChild>
           <h1>이재민</h1>

--- a/src/components/layout/mdx.tsx
+++ b/src/components/layout/mdx.tsx
@@ -1,7 +1,7 @@
 import { CornerUpLeft } from 'lucide-react';
 import dynamic from 'next/dynamic';
 import Link from 'next/link';
-import type { BlogPosting, WithContext } from 'schema-dts';
+import type { BreadcrumbList, BlogPosting, WithContext } from 'schema-dts';
 
 import { Giscus } from '@/components/comments/giscus';
 import {
@@ -35,6 +35,8 @@ interface MdxLayoutProps {
 export function MdxLayout({ post, type, seriesInfo }: MdxLayoutProps) {
   const { title, publishedAt, summary, description, image } = post.metadata;
 
+  const typeName = type === 'article' ? '기술 이야기' : '작업 목록';
+
   const jsonLd: WithContext<BlogPosting> = {
     '@context': 'https://schema.org',
     '@type': 'BlogPosting',
@@ -53,6 +55,31 @@ export function MdxLayout({ post, type, seriesInfo }: MdxLayoutProps) {
     },
   };
 
+  const breadcrumbJsonLd: WithContext<BreadcrumbList> = {
+    '@context': 'https://schema.org',
+    '@type': 'BreadcrumbList',
+    itemListElement: [
+      {
+        '@type': 'ListItem',
+        position: 1,
+        name: '홈',
+        item: siteMetadata.siteUrl,
+      },
+      {
+        '@type': 'ListItem',
+        position: 2,
+        name: typeName,
+        item: `${siteMetadata.siteUrl}/${type}`,
+      },
+      {
+        '@type': 'ListItem',
+        position: 3,
+        name: title,
+        item: `${siteMetadata.siteUrl}/${type}/${post.slug}`,
+      },
+    ],
+  };
+
   return (
     <main className="relative mx-auto my-0 min-h-screen max-w-2xl overflow-hidden px-6 py-32">
       <section id="BenddDoc">
@@ -61,6 +88,13 @@ export function MdxLayout({ post, type, seriesInfo }: MdxLayoutProps) {
           suppressHydrationWarning
           dangerouslySetInnerHTML={{
             __html: JSON.stringify(jsonLd),
+          }}
+        />
+        <script
+          type="application/ld+json"
+          suppressHydrationWarning
+          dangerouslySetInnerHTML={{
+            __html: JSON.stringify(breadcrumbJsonLd),
           }}
         />
         <div className="fixed bottom-16 left-5 top-24 hidden flex-col overflow-hidden lg:flex">


### PR DESCRIPTION
## Summary
- 루트 레이아웃에 **WebSite** JSON-LD, 홈페이지에 **Person** JSON-LD + 명시적 metadata 추가
- 글 상세 페이지(`article`, `craft`)에 **BreadcrumbList** JSON-LD 추가 (홈 → 카테고리 → 글)
- 목록 페이지(`article`, `craft`, `series`)에 **CollectionPage + ItemList** JSON-LD 추가

## Why
Google 검색에서 하위 페이지가 Sitelinks로 표시되려면 사이트 구조를 구조화된 데이터로 명시적으로 전달해야 한다. 현재 BlogPosting 스키마만 존재하여 사이트 계층 정보가 부족했다.

## Changes
| 파일 | 추가된 스키마 | 목적 |
|---|---|---|
| `src/app/layout.tsx` | WebSite | 사이트 identity + publisher |
| `src/app/page.tsx` | Person + metadata | 저자 인식, Knowledge Panel |
| `src/components/layout/mdx.tsx` | BreadcrumbList | SERP 빵크럼 표시 |
| `src/app/article/page.tsx` | CollectionPage + ItemList | 글 목록 구조 전달 |
| `src/app/craft/page.tsx` | CollectionPage + ItemList | Craft 목록 구조 전달 |
| `src/app/article/series/[id]/page.tsx` | CollectionPage + ItemList | 시리즈 목록 구조 전달 |

## Notes
- 홈페이지 `title`은 layout template (`%s • 이재민`) 충돌 방지를 위해 `title.absolute` 사용
- SearchAction은 현재 검색 기능 미구현이므로 추가하지 않음
- Sitelinks는 Google이 자동 생성하므로 배포 후 2-4주 내 반영 예상

## Test plan
- [x] `pnpm check-types` 통과
- [x] `pnpm build` 성공 (28 pages generated)
- [ ] Vercel Preview 배포 후 [Google Rich Results Test](https://search.google.com/test/rich-results)로 JSON-LD 유효성 검증
- [ ] 배포 2-4주 후 Google Search Console에서 Sitelinks 노출 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신기능**
  * 사이트 전반에 Schema.org 기반 구조화된 데이터(JSON-LD)를 추가해 검색엔진 노출을 개선했습니다.
  * 홈페이지에 Person·WebSite 정보가 포함되어 풍부한 검색 결과를 제공합니다.
  * 기사 목록, 시리즈, 작업(크래프트) 페이지에 Collection/ItemList 정보가 추가되어 항목별 노출이 향상됩니다.
  * 개별 게시물에 대한 Breadcrumb 정보가 추가되어 계층적 검색 표시가 강화됩니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->