### PR TITLE
fix(zoom): 이미지 축소 후 스크롤 위치 원위치 복귀 방지

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -154,7 +154,7 @@ Vercel-only. No GitHub Actions CI. Pipeline: `git push` → Vercel auto-deploys 
 | -------------------------------------------- | ------------------------------------------------------------- |
 | [docs/architecture.md](docs/architecture.md) | Content system, layer dependencies, routing, security headers |
 | [docs/conventions.md](docs/conventions.md)   | Naming rules, file structure, MDX patterns, CSS, commits      |
-| [docs/pitfalls.md](docs/pitfalls.md)         | 23 common agent mistakes with correct/incorrect examples      |
+| [docs/pitfalls.md](docs/pitfalls.md)         | 24 common agent mistakes with correct/incorrect examples      |
 | [docs/decisions.md](docs/decisions.md)       | ADR-lite: why we chose specific patterns (Zod, HSL, etc.)     |
 | [docs/commands.md](docs/commands.md)         | Dev commands, test runners, build workflow                    |
 | [docs/design-docs/](docs/design-docs/)       | Design documents for specific technical decisions             |

--- a/docs/pitfalls.md
+++ b/docs/pitfalls.md
@@ -197,3 +197,15 @@ vercel --prod --yes
 ```
 
 **주의**: `x-vercel-error: INTERNAL_UNEXPECTED_ERROR`는 Next.js 애플리케이션 에러가 아니라 Vercel 플랫폼 수준 에러다. 코드 변경으로 해결하려 하지 않는다.
+
+## P24: focus() 호출 시 스크롤 점프
+
+`element.focus()`의 기본 동작은 대상 요소가 뷰포트 밖에 있으면 **자동으로 스크롤하여 화면에 보이게 한다**. 모달/줌/오버레이를 닫은 후 포커스를 복원할 때, 사용자가 스크롤을 이동한 상태면 원래 요소 위치로 강제 스크롤되어 UX가 깨진다.
+
+```typescript
+// 올바름 — 포커스는 복원하되 스크롤 이동 방지
+element.focus({ preventScroll: true });
+
+// 잘못됨 — 요소가 뷰포트 밖이면 브라우저가 자동 스크롤
+element.focus();
+```

--- a/src/mdx/components/zoom-image/zoom-image.spec.tsx
+++ b/src/mdx/components/zoom-image/zoom-image.spec.tsx
@@ -379,6 +379,54 @@ describe('MDXZoomImage', () => {
       expect(screen.getByRole('dialog')).toBeDefined();
     });
 
+    it('포커스 복원 시 preventScroll: true로 호출한다', () => {
+      render(<MDXZoomImage src="/test.png" alt="줌 테스트" />);
+      const img = screen.getByAltText('줌 테스트');
+      const focusSpy = vi.spyOn(img, 'focus');
+
+      fireEvent.click(img);
+      focusSpy.mockClear();
+
+      fireEvent.click(screen.getByRole('dialog'));
+      const clone = screen.getAllByAltText('줌 테스트')[1];
+      fireEvent.transitionEnd(clone);
+
+      expect(focusSpy).toHaveBeenCalledWith({ preventScroll: true });
+      focusSpy.mockRestore();
+    });
+
+    it('wheel로 닫을 때도 preventScroll: true로 포커스를 복원한다', () => {
+      render(<MDXZoomImage src="/test.png" alt="줌 테스트" />);
+      const img = screen.getByAltText('줌 테스트');
+      const focusSpy = vi.spyOn(img, 'focus');
+
+      fireEvent.click(img);
+      focusSpy.mockClear();
+
+      fireEvent.wheel(screen.getByRole('dialog'), { deltaY: 100, deltaX: 0 });
+      const clone = screen.getAllByAltText('줌 테스트')[1];
+      fireEvent.transitionEnd(clone);
+
+      expect(focusSpy).toHaveBeenCalledWith({ preventScroll: true });
+      focusSpy.mockRestore();
+    });
+
+    it('Escape로 닫을 때도 preventScroll: true로 포커스를 복원한다', () => {
+      render(<MDXZoomImage src="/test.png" alt="줌 테스트" />);
+      const img = screen.getByAltText('줌 테스트');
+      const focusSpy = vi.spyOn(img, 'focus');
+
+      fireEvent.keyDown(img, { key: 'Enter' });
+      focusSpy.mockClear();
+
+      fireEvent.keyDown(document, { key: 'Escape' });
+      const clone = screen.getAllByAltText('줌 테스트')[1];
+      fireEvent.transitionEnd(clone);
+
+      expect(focusSpy).toHaveBeenCalledWith({ preventScroll: true });
+      focusSpy.mockRestore();
+    });
+
     it('줌인→줌아웃→클릭으로 다시 줌인할 수 있다', () => {
       render(<MDXZoomImage src="/test.png" alt="줌 테스트" />);
       const img = screen.getByAltText('줌 테스트');

--- a/src/mdx/components/zoom-image/zoom-image.tsx
+++ b/src/mdx/components/zoom-image/zoom-image.tsx
@@ -181,7 +181,7 @@ function ZoomableImage({
   useEffect(() => {
     if (!zoomState && shouldRestoreFocus.current) {
       shouldRestoreFocus.current = false;
-      imgRef.current?.focus();
+      imgRef.current?.focus({ preventScroll: true });
     }
   }, [zoomState]);
 


### PR DESCRIPTION
## Summary

- 이미지 확대 → 스크롤 → 축소 완료 후 스크롤이 원래 이미지 위치로 돌아가는 버그 수정
- 원인: `focus()` 기본 동작이 뷰포트 밖 요소에 자동 스크롤 → `focus({ preventScroll: true })`로 방지
- `preventScroll: true` 검증 유닛 테스트 3개 추가 (68개 전체 통과)
- `docs/pitfalls.md`에 P24 (focus 스크롤 점프) 함정 추가

## Test plan

- [x] 유닛 테스트 68/68 통과 (기존 65 + 신규 3)
- [x] 로컬에서 이미지 줌 → 스크롤 → 축소 후 스크롤 위치 유지 확인
- [x] Tab 키로 축소 후 원본 이미지에 포커스 링 표시 확인


🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **버그 수정**
  * 이미지 줌을 닫을 때 초점 복원 시 페이지가 불필요하게 스크롤되는 문제를 수정했습니다 (초점 복원 시 스크롤 억제).

* **테스트**
  * 줌 종료 후 초점 복원 동작을 검증하는 포커스 관리 관련 테스트를 추가했습니다.

* **문서**
  * element.focus()로 인한 스크롤 점프를 방지하기 위한 권장 사용법을 문서에 추가했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->