### PR TITLE
feat(webmcp): AI 에이전트 도구 표면 추가

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@
 .pnpm-store/
 .omc/
 .claude/
+.worktrees/
 
 # ide
 .idea/

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -119,8 +119,8 @@ unless the browser exposes `navigator.modelContext`.
 The provider registers route-relevant tools only during idle time and aborts
 the previous registration on route changes. Content search does not build a
 global index during page load. It fetches `/api/webmcp/content-index` only when
-the `find_content` tool runs, then reuses the in-memory result for the current
-browser session.
+the `find_content` or `open_content` tool runs, then reuses the in-memory result
+for the current browser session.
 
 The WebMCP surface is intentionally limited to safe visible actions:
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -109,3 +109,28 @@ src/components/{domain}/model/    <- 직접 import 금지
 - `X-Frame-Options: DENY` (iframe 삽입 차단)
 - `Strict-Transport-Security` (HTTPS 강제)
 - `X-Content-Type-Options: nosniff`
+
+## WebMCP
+
+WebMCP is implemented as a progressive enhancement. The root layout dynamically
+mounts `WebMCPProvider` with `ssr: false`, and the provider exits immediately
+unless the browser exposes `navigator.modelContext`.
+
+The provider registers route-relevant tools only during idle time and aborts
+the previous registration on route changes. Content search does not build a
+global index during page load. It fetches `/api/webmcp/content-index` only when
+the `find_content` tool runs, then reuses the in-memory result for the current
+browser session.
+
+The WebMCP surface is intentionally limited to safe visible actions:
+
+- internal navigation
+- content metadata search
+- current article/craft context snippets
+- heading scroll
+- code block copy
+- theme and sound settings
+- shuffle letters playground execution
+
+External links and `mailto:` links are not opened automatically by WebMCP tools.
+Cross-origin iframes do not receive `allow="tools"`.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -125,10 +125,12 @@ browser session.
 The WebMCP surface is intentionally limited to safe visible actions:
 
 - internal navigation
+- route/action introspection
 - content metadata search
 - current article/craft context snippets
 - heading scroll
 - code block copy
+- current URL copy
 - theme and sound settings
 - shuffle letters playground execution
 

--- a/docs/conventions.md
+++ b/docs/conventions.md
@@ -178,3 +178,23 @@ Inter (sans)와 Fira Mono (mono)를 Google Fonts에서 로드한다. CSS 변수�
 - `--font-mono` -> Fira Mono
 
 `display: 'swap'` 설정으로 FOUT를 방지한다. 필요한 weight만 로드한다 (전체 로드 금지).
+
+## WebMCP
+
+WebMCP code lives under `src/components/webmcp/` and follows the domain
+component barrel export rule. Import it as `@/components/webmcp`.
+
+Rules:
+
+- Always feature-detect `navigator.modelContext` before creating schemas,
+  scanning DOM, or registering tools.
+- Register tools during idle time through `registerWebMCPTools`.
+- Use `AbortController` cleanup for every registration lifecycle.
+- Keep tool outputs small. Article and craft tools may return metadata,
+  TL;DR, headings, and short excerpts, but not full MDX bodies.
+- Keep external navigation manual. WebMCP tools may return external URLs but
+  must not automatically open them.
+- Add declarative attributes only to real forms with visible user-facing
+  controls.
+- Use HSL CSS variables for `:tool-form-active` and `:tool-submit-active`
+  styles.

--- a/docs/conventions.md
+++ b/docs/conventions.md
@@ -186,8 +186,8 @@ component barrel export rule. Import it as `@/components/webmcp`.
 
 Rules:
 
-- Always feature-detect `navigator.modelContext` before creating schemas,
-  scanning DOM, or registering tools.
+- Always feature-detect `navigator.modelContext` before building tool
+  descriptors, scanning DOM, fetching content, or registering tools.
 - Register tools during idle time through `registerWebMCPTools`.
 - Use `AbortController` cleanup for every registration lifecycle.
 - Keep tool outputs small. Article and craft tools may return metadata,

--- a/docs/superpowers/plans/2026-05-28-webmcp-implementation.md
+++ b/docs/superpowers/plans/2026-05-28-webmcp-implementation.md
@@ -1,0 +1,2722 @@
+# WebMCP Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add production-safe WebMCP support across bendd.me so AI agents can use structured tools for navigation, content discovery, document actions, settings, and the shuffle letters playground.
+
+**Architecture:** WebMCP is a progressive enhancement mounted by a client-only provider under `src/components/webmcp/`. The provider feature-detects `navigator.modelContext`, registers only route-relevant tools during idle time, and unregisters with `AbortController` on route changes. Content search uses a lazy `/api/webmcp/content-index` endpoint so unsupported browsers do not pay the cost of building a content index.
+
+**Tech Stack:** Next.js 14 App Router, React 18, TypeScript, Vitest + jsdom, Zustand, next-themes, WebMCP Imperative API, WebMCP Declarative API.
+
+---
+
+## Scope Check
+
+The approved spec covers four visible product surfaces: global navigation/settings, article/craft content, MDX document actions, and shuffle playground interaction. They share one WebMCP provider, one registration helper, and one route-aware tool layer, so this can remain a single implementation plan. The work is split into focused commits so each part is testable and reversible.
+
+## File Structure
+
+- Create `src/components/webmcp/types/webmcp.d.ts`: local type declarations for the experimental browser API.
+- Create `src/components/webmcp/lib/schemas.ts`: JSON Schema constants and tool descriptor helper.
+- Create `src/components/webmcp/lib/register-tool.ts`: feature detection and `AbortController`-based registration helper.
+- Create `src/components/webmcp/lib/register-tool.spec.ts`: registration helper unit tests.
+- Create `src/components/webmcp/index.ts`: public barrel export after the provider exists.
+- Create `src/components/webmcp/lib/content-index.ts`: server-safe content index builder without MDX body text.
+- Create `src/components/webmcp/lib/content-index.spec.ts`: content index unit tests.
+- Create `src/app/api/webmcp/content-index/route.ts`: lazy content index route.
+- Create `src/app/api/webmcp/content-index/route.spec.ts`: route response unit tests.
+- Create `src/components/webmcp/lib/content-snapshot.ts`: DOM snapshot utilities for current document, headings, code blocks, and series links.
+- Create `src/components/webmcp/lib/content-snapshot.spec.ts`: DOM snapshot unit tests.
+- Modify `src/components/layout/mdx.tsx`: add stable `data-webmcp-*` attributes for content metadata.
+- Modify `src/components/series/ui/series-navigation-top.tsx`: mark series link for `open_series`.
+- Modify `src/components/series/ui/series-navigation-bottom.tsx`: mark series, previous, and next links for `open_series`.
+- Modify `src/mdx/components/pre/pre.tsx`: mark code blocks for `copy_code_block`.
+- Create `src/components/webmcp/model/tool-handlers.ts`: route-independent tool handler factory.
+- Create `src/components/webmcp/model/tool-handlers.spec.ts`: handler unit tests with mock DOM/router/clipboard.
+- Create `src/components/webmcp/model/use-webmcp-tools.ts`: React hook that binds handlers to router/theme/sound state and returns route-relevant descriptors.
+- Create `src/components/webmcp/ui/webmcp-provider.tsx`: idle registration lifecycle.
+- Create `src/components/webmcp/ui/webmcp-provider.spec.tsx`: provider lifecycle tests.
+- Modify `src/app/layout.tsx`: dynamically mount `WebMCPProvider` with `ssr: false`.
+- Modify `src/components/sound/model/sound-store.ts`: add explicit `setSoundEnabled` action used by `set_sound`.
+- Modify `src/mdx/components/shuffle-letters-demo/shuffle-letters-demo.tsx`: add declarative WebMCP annotations and custom-event execution.
+- Modify `src/app/playground/shuffle-letters/page.tsx`: add declarative annotations and custom-event execution on the standalone playground.
+- Create `src/mdx/components/shuffle-letters-demo/shuffle-letters-demo.spec.tsx`: test WebMCP event execution and form annotations.
+- Modify `src/globals.css`: add HSL-based `:tool-form-active` and `:tool-submit-active` focus styles.
+- Modify `next.config.mjs`: add `tools=(self)` to `Permissions-Policy`.
+- Modify `docs/architecture.md`: document WebMCP architecture and performance contract.
+- Modify `docs/conventions.md`: document WebMCP implementation rules.
+
+## Task 1: WebMCP Types, Schemas, and Registration Helper
+
+**Files:**
+
+- Create: `src/components/webmcp/types/webmcp.d.ts`
+- Create: `src/components/webmcp/lib/schemas.ts`
+- Create: `src/components/webmcp/lib/register-tool.ts`
+- Create: `src/components/webmcp/lib/register-tool.spec.ts`
+
+- [ ] **Step 1: Write the failing registration tests**
+
+Create `src/components/webmcp/lib/register-tool.spec.ts`:
+
+```ts
+import { describe, expect, it, vi } from 'vitest';
+
+import { hasModelContext, registerWebMCPTools } from './register-tool';
+import type { WebMCPToolDescriptor } from '../types/webmcp';
+
+function createTool(name: string): WebMCPToolDescriptor {
+  return {
+    name,
+    description: `${name} description`,
+    inputSchema: {
+      type: 'object',
+      properties: {},
+      additionalProperties: false,
+    },
+    execute: vi.fn(),
+  };
+}
+
+describe('registerWebMCPTools', () => {
+  it('returns false when navigator.modelContext is missing', () => {
+    expect(hasModelContext({} as Navigator)).toBe(false);
+  });
+
+  it('returns true when navigator.modelContext.registerTool exists', () => {
+    expect(
+      hasModelContext({
+        modelContext: {
+          registerTool: vi.fn(),
+        },
+      } as unknown as Navigator)
+    ).toBe(true);
+  });
+
+  it('registers each tool with one abort signal and cleans up by aborting it', () => {
+    const registerTool = vi.fn();
+    const navigatorMock = {
+      modelContext: { registerTool },
+    } as unknown as Navigator;
+    const tools = [createTool('get_site_context'), createTool('navigate_site')];
+
+    const cleanup = registerWebMCPTools(tools, navigatorMock);
+
+    expect(registerTool).toHaveBeenCalledTimes(2);
+    const firstOptions = registerTool.mock.calls[0][1] as {
+      signal: AbortSignal;
+    };
+    const secondOptions = registerTool.mock.calls[1][1] as {
+      signal: AbortSignal;
+    };
+    expect(firstOptions.signal).toBe(secondOptions.signal);
+    expect(firstOptions.signal.aborted).toBe(false);
+
+    cleanup();
+
+    expect(firstOptions.signal.aborted).toBe(true);
+  });
+
+  it('does nothing and returns a stable cleanup function when unsupported', () => {
+    const cleanup = registerWebMCPTools([createTool('get_site_context')], {
+      modelContext: undefined,
+    } as unknown as Navigator);
+
+    expect(() => cleanup()).not.toThrow();
+  });
+});
+```
+
+- [ ] **Step 2: Run the failing tests**
+
+Run:
+
+```bash
+pnpm test:unit src/components/webmcp/lib/register-tool.spec.ts
+```
+
+Expected: FAIL because `src/components/webmcp/lib/register-tool.ts` does not exist.
+
+- [ ] **Step 3: Add the experimental WebMCP types**
+
+Create `src/components/webmcp/types/webmcp.d.ts`:
+
+```ts
+export type WebMCPJSONSchema = {
+  type: string;
+  properties?: Record<string, WebMCPJSONSchema>;
+  required?: string[];
+  additionalProperties?: boolean;
+  enum?: readonly string[];
+  const?: string | number | boolean;
+  title?: string;
+  description?: string;
+  minimum?: number;
+  maximum?: number;
+  anyOf?: readonly WebMCPJSONSchema[];
+};
+
+export type WebMCPToolAnnotations = {
+  readOnlyHint?: boolean;
+  destructiveHint?: boolean;
+  idempotentHint?: boolean;
+  openWorldHint?: boolean;
+};
+
+export type WebMCPToolDescriptor<Input = unknown, Output = unknown> = {
+  name: string;
+  description: string;
+  inputSchema: WebMCPJSONSchema;
+  annotations?: WebMCPToolAnnotations;
+  execute: (input: Input) => Output | Promise<Output>;
+};
+
+export type WebMCPRegisterOptions = {
+  signal?: AbortSignal;
+};
+
+export type WebMCPModelContext = {
+  registerTool: (
+    tool: WebMCPToolDescriptor,
+    options?: WebMCPRegisterOptions
+  ) => void;
+};
+
+declare global {
+  interface Navigator {
+    modelContext?: WebMCPModelContext;
+  }
+}
+
+declare module 'react' {
+  interface FormHTMLAttributes<T> {
+    toolname?: string;
+    tooldescription?: string;
+    toolautosubmit?: boolean | '';
+  }
+
+  interface HTMLAttributes<T> {
+    toolparamdescription?: string;
+  }
+}
+```
+
+- [ ] **Step 4: Add schema constants**
+
+Create `src/components/webmcp/lib/schemas.ts`:
+
+```ts
+import type {
+  WebMCPJSONSchema,
+  WebMCPToolAnnotations,
+  WebMCPToolDescriptor,
+} from '@/components/webmcp/types/webmcp';
+
+export type WebMCPToolName =
+  | 'navigate_site'
+  | 'get_site_context'
+  | 'toggle_theme'
+  | 'set_sound'
+  | 'copy_current_url'
+  | 'find_content'
+  | 'open_content'
+  | 'get_current_content_context'
+  | 'open_series'
+  | 'jump_to_heading'
+  | 'copy_code_block'
+  | 'list_page_actions'
+  | 'run_shuffle_letters'
+  | 'stop_shuffle_letters';
+
+export const emptyObjectSchema = {
+  type: 'object',
+  properties: {},
+  additionalProperties: false,
+} satisfies WebMCPJSONSchema;
+
+const stringSchema = {
+  type: 'string',
+} satisfies WebMCPJSONSchema;
+
+const numberSchema = (minimum: number, maximum: number) =>
+  ({
+    type: 'number',
+    minimum,
+    maximum,
+  }) satisfies WebMCPJSONSchema;
+
+const enumSchema = (values: readonly string[]) =>
+  ({
+    type: 'string',
+    enum: values,
+  }) satisfies WebMCPJSONSchema;
+
+export const webMCPSchemas = {
+  navigateSite: {
+    type: 'object',
+    properties: {
+      destination: enumSchema([
+        'home',
+        'article',
+        'craft',
+        'shuffle-playground',
+      ]),
+    },
+    required: ['destination'],
+    additionalProperties: false,
+  },
+  setSound: {
+    type: 'object',
+    properties: {
+      enabled: { type: 'boolean' },
+    },
+    required: ['enabled'],
+    additionalProperties: false,
+  },
+  findContent: {
+    type: 'object',
+    properties: {
+      query: stringSchema,
+      type: enumSchema(['all', 'article', 'craft']),
+      limit: numberSchema(1, 10),
+    },
+    required: ['query'],
+    additionalProperties: false,
+  },
+  openContent: {
+    type: 'object',
+    properties: {
+      type: enumSchema(['article', 'craft']),
+      slug: stringSchema,
+    },
+    required: ['type', 'slug'],
+    additionalProperties: false,
+  },
+  openSeries: {
+    type: 'object',
+    properties: {
+      target: enumSchema(['series', 'previous', 'next']),
+    },
+    required: ['target'],
+    additionalProperties: false,
+  },
+  jumpToHeading: {
+    type: 'object',
+    properties: {
+      headingId: stringSchema,
+    },
+    required: ['headingId'],
+    additionalProperties: false,
+  },
+  copyCodeBlock: {
+    type: 'object',
+    properties: {
+      index: numberSchema(0, 999),
+    },
+    required: ['index'],
+    additionalProperties: false,
+  },
+  runShuffleLetters: {
+    type: 'object',
+    properties: {
+      text: stringSchema,
+      iterations: numberSchema(1, 50),
+      fps: numberSchema(1, 60),
+    },
+    required: ['text', 'iterations', 'fps'],
+    additionalProperties: false,
+  },
+} satisfies Record<string, WebMCPJSONSchema>;
+
+export function createToolDescriptor<Input, Output>({
+  name,
+  description,
+  inputSchema,
+  annotations,
+  execute,
+}: {
+  name: WebMCPToolName;
+  description: string;
+  inputSchema: WebMCPJSONSchema;
+  annotations?: WebMCPToolAnnotations;
+  execute: (input: Input) => Output | Promise<Output>;
+}): WebMCPToolDescriptor<Input, Output> {
+  return {
+    name,
+    description,
+    inputSchema,
+    annotations,
+    execute,
+  };
+}
+```
+
+- [ ] **Step 5: Add the registration helper**
+
+Create `src/components/webmcp/lib/register-tool.ts`:
+
+```ts
+import type { WebMCPToolDescriptor } from '@/components/webmcp/types/webmcp';
+
+const noop = () => {};
+
+export function hasModelContext(
+  navigatorLike: Navigator | undefined = typeof navigator === 'undefined'
+    ? undefined
+    : navigator
+): navigatorLike is Navigator & {
+  modelContext: NonNullable<Navigator['modelContext']>;
+} {
+  return typeof navigatorLike?.modelContext?.registerTool === 'function';
+}
+
+export function registerWebMCPTools(
+  tools: readonly WebMCPToolDescriptor[],
+  navigatorLike: Navigator | undefined = typeof navigator === 'undefined'
+    ? undefined
+    : navigator
+) {
+  if (!hasModelContext(navigatorLike)) {
+    return noop;
+  }
+
+  const controller = new AbortController();
+
+  for (const tool of tools) {
+    navigatorLike.modelContext.registerTool(tool, {
+      signal: controller.signal,
+    });
+  }
+
+  return () => {
+    controller.abort();
+  };
+}
+```
+
+- [ ] **Step 6: Run the registration tests**
+
+Run:
+
+```bash
+pnpm test:unit src/components/webmcp/lib/register-tool.spec.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 7: Commit**
+
+Run:
+
+```bash
+git add src/components/webmcp/types/webmcp.d.ts src/components/webmcp/lib/schemas.ts src/components/webmcp/lib/register-tool.ts src/components/webmcp/lib/register-tool.spec.ts
+git commit -m "feat(webmcp): 도구 등록 기반 구조 추가"
+```
+
+## Task 2: Lazy Content Index API
+
+**Files:**
+
+- Create: `src/components/webmcp/lib/content-index.ts`
+- Create: `src/components/webmcp/lib/content-index.spec.ts`
+- Create: `src/app/api/webmcp/content-index/route.ts`
+- Create: `src/app/api/webmcp/content-index/route.spec.ts`
+
+- [ ] **Step 1: Write failing content index tests**
+
+Create `src/components/webmcp/lib/content-index.spec.ts`:
+
+```ts
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('@/mdx/mdx', () => ({
+  readArticles: () => [
+    {
+      slug: 'agentic-interfaces',
+      metadata: {
+        title: 'Agentic interfaces',
+        summary: 'Agent UI notes',
+        description: 'How agents use visible interfaces.',
+        publishedAt: '2026-05-10',
+        category: 'ai',
+        series: 'ai-agents',
+        seriesOrder: 2,
+      },
+      content: 'FULL ARTICLE BODY MUST NOT LEAK',
+    },
+  ],
+  readCraftArticles: () => [
+    {
+      slug: 'shuffle-demo',
+      metadata: {
+        title: 'Shuffle demo',
+        summary: 'Motion demo',
+        description: 'A small animation experiment.',
+        publishedAt: '2026-04-01',
+        category: 'motion',
+      },
+      content: 'FULL CRAFT BODY MUST NOT LEAK',
+    },
+  ],
+  sortByDateDesc: <T>(items: readonly T[]) => [...items],
+  getSeriesBadges: () =>
+    new Map([
+      [
+        'agentic-interfaces',
+        {
+          id: 'ai-agents',
+          name: 'AI Agents',
+          order: 2,
+          total: 3,
+        },
+      ],
+    ]),
+}));
+
+import { createWebMCPContentIndex } from './content-index';
+
+describe('createWebMCPContentIndex', () => {
+  it('returns article and craft metadata without MDX body content', () => {
+    const items = createWebMCPContentIndex();
+
+    expect(items).toEqual([
+      {
+        type: 'article',
+        slug: 'agentic-interfaces',
+        title: 'Agentic interfaces',
+        summary: 'Agent UI notes',
+        description: 'How agents use visible interfaces.',
+        publishedAt: '2026-05-10',
+        category: 'ai',
+        href: '/article/agentic-interfaces',
+        series: {
+          id: 'ai-agents',
+          name: 'AI Agents',
+          order: 2,
+        },
+      },
+      {
+        type: 'craft',
+        slug: 'shuffle-demo',
+        title: 'Shuffle demo',
+        summary: 'Motion demo',
+        description: 'A small animation experiment.',
+        publishedAt: '2026-04-01',
+        category: 'motion',
+        href: '/craft/shuffle-demo',
+      },
+    ]);
+    expect(JSON.stringify(items)).not.toContain('FULL ARTICLE BODY');
+    expect(JSON.stringify(items)).not.toContain('FULL CRAFT BODY');
+  });
+});
+```
+
+- [ ] **Step 2: Run the failing content index test**
+
+Run:
+
+```bash
+pnpm test:unit src/components/webmcp/lib/content-index.spec.ts
+```
+
+Expected: FAIL because `content-index.ts` does not exist.
+
+- [ ] **Step 3: Implement the content index builder**
+
+Create `src/components/webmcp/lib/content-index.ts`:
+
+```ts
+import {
+  getSeriesBadges,
+  readArticles,
+  readCraftArticles,
+  sortByDateDesc,
+} from '@/mdx/mdx';
+
+export type WebMCPContentIndexItem = {
+  type: 'article' | 'craft';
+  slug: string;
+  title: string;
+  summary: string;
+  description: string;
+  publishedAt: string;
+  category: string;
+  href: string;
+  series?: {
+    id: string;
+    name: string;
+    order: number;
+  };
+};
+
+export function createWebMCPContentIndex(): WebMCPContentIndexItem[] {
+  const articles = sortByDateDesc(readArticles());
+  const crafts = sortByDateDesc(readCraftArticles());
+  const articleBadges = getSeriesBadges(articles);
+
+  const articleItems = articles.map(article => {
+    const series = articleBadges.get(article.slug);
+
+    return {
+      type: 'article' as const,
+      slug: article.slug,
+      title: article.metadata.title,
+      summary: article.metadata.summary,
+      description: article.metadata.description,
+      publishedAt: article.metadata.publishedAt,
+      category: article.metadata.category,
+      href: `/article/${article.slug}`,
+      ...(series && {
+        series: {
+          id: series.id,
+          name: series.name,
+          order: series.order,
+        },
+      }),
+    };
+  });
+
+  const craftItems = crafts.map(craft => ({
+    type: 'craft' as const,
+    slug: craft.slug,
+    title: craft.metadata.title,
+    summary: craft.metadata.summary,
+    description: craft.metadata.description,
+    publishedAt: craft.metadata.publishedAt,
+    category: craft.metadata.category,
+    href: `/craft/${craft.slug}`,
+  }));
+
+  return [...articleItems, ...craftItems];
+}
+```
+
+- [ ] **Step 4: Run the content index test**
+
+Run:
+
+```bash
+pnpm test:unit src/components/webmcp/lib/content-index.spec.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Write failing route tests**
+
+Create `src/app/api/webmcp/content-index/route.spec.ts`:
+
+```ts
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('@/components/webmcp/lib/content-index', () => ({
+  createWebMCPContentIndex: () => [
+    {
+      type: 'article',
+      slug: 'agentic-interfaces',
+      title: 'Agentic interfaces',
+      summary: 'Agent UI notes',
+      description: 'How agents use visible interfaces.',
+      publishedAt: '2026-05-10',
+      category: 'ai',
+      href: '/article/agentic-interfaces',
+    },
+  ],
+}));
+
+import { GET } from './route';
+
+describe('/api/webmcp/content-index', () => {
+  it('returns a small JSON content index with cache headers', async () => {
+    const response = await GET();
+    const body = await response.json();
+
+    expect(response.headers.get('Content-Type')).toContain('application/json');
+    expect(response.headers.get('Cache-Control')).toBe(
+      'public, max-age=300, s-maxage=3600'
+    );
+    expect(body).toEqual({
+      items: [
+        {
+          type: 'article',
+          slug: 'agentic-interfaces',
+          title: 'Agentic interfaces',
+          summary: 'Agent UI notes',
+          description: 'How agents use visible interfaces.',
+          publishedAt: '2026-05-10',
+          category: 'ai',
+          href: '/article/agentic-interfaces',
+        },
+      ],
+    });
+  });
+});
+```
+
+- [ ] **Step 6: Run the failing route test**
+
+Run:
+
+```bash
+pnpm test:unit src/app/api/webmcp/content-index/route.spec.ts
+```
+
+Expected: FAIL because `route.ts` does not exist.
+
+- [ ] **Step 7: Implement the content index route**
+
+Create `src/app/api/webmcp/content-index/route.ts`:
+
+```ts
+import { createWebMCPContentIndex } from '@/components/webmcp/lib/content-index';
+
+export const dynamic = 'force-static';
+
+export async function GET() {
+  return Response.json(
+    {
+      items: createWebMCPContentIndex(),
+    },
+    {
+      headers: {
+        'Cache-Control': 'public, max-age=300, s-maxage=3600',
+      },
+    }
+  );
+}
+```
+
+- [ ] **Step 8: Run the route and content index tests**
+
+Run:
+
+```bash
+pnpm test:unit src/components/webmcp/lib/content-index.spec.ts src/app/api/webmcp/content-index/route.spec.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 9: Commit**
+
+Run:
+
+```bash
+git add src/components/webmcp/lib/content-index.ts src/components/webmcp/lib/content-index.spec.ts src/app/api/webmcp/content-index/route.ts src/app/api/webmcp/content-index/route.spec.ts
+git commit -m "feat(webmcp): 콘텐츠 인덱스 API 추가"
+```
+
+## Task 3: DOM Snapshot Utilities and Stable Page Markers
+
+**Files:**
+
+- Create: `src/components/webmcp/lib/content-snapshot.ts`
+- Create: `src/components/webmcp/lib/content-snapshot.spec.ts`
+- Modify: `src/components/layout/mdx.tsx`
+- Modify: `src/components/series/ui/series-navigation-top.tsx`
+- Modify: `src/components/series/ui/series-navigation-bottom.tsx`
+- Modify: `src/mdx/components/pre/pre.tsx`
+
+- [ ] **Step 1: Write failing snapshot tests**
+
+Create `src/components/webmcp/lib/content-snapshot.spec.ts`:
+
+```ts
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import {
+  getCodeBlockText,
+  getCurrentContentContext,
+  getPageActions,
+  getSeriesTargetHref,
+  jumpToHeading,
+} from './content-snapshot';
+
+describe('content-snapshot', () => {
+  beforeEach(() => {
+    document.body.innerHTML = `
+      <main>
+        <section
+          data-webmcp-content
+          data-webmcp-content-type="article"
+          data-webmcp-slug="agentic-interfaces"
+          data-webmcp-title="Agentic interfaces"
+          data-webmcp-published-at="2026-05-10"
+          data-webmcp-description="How agents use visible interfaces."
+          data-webmcp-summary="Agent UI notes"
+          data-webmcp-series-id="ai-agents"
+          data-webmcp-series-name="AI Agents"
+        >
+          <blockquote><p><strong>TL;DR</strong>: Visible tools help agents.</p></blockquote>
+          <a href="/article/series/ai-agents" data-webmcp-series-target="series">Series</a>
+          <a href="/article/previous" data-webmcp-series-target="previous">Previous</a>
+          <article>
+            <p>First paragraph that becomes a short excerpt for agent context.</p>
+            <h2 id="overview">Overview</h2>
+            <h4 id="details">Details</h4>
+            <pre data-webmcp-code-block><code>const value = 1;</code></pre>
+          </article>
+        </section>
+      </main>
+    `;
+  });
+
+  it('extracts current content context without full body text', () => {
+    expect(getCurrentContentContext(document)).toEqual({
+      ok: true,
+      type: 'article',
+      slug: 'agentic-interfaces',
+      title: 'Agentic interfaces',
+      publishedAt: '2026-05-10',
+      description: 'How agents use visible interfaces.',
+      summary: 'Agent UI notes',
+      series: {
+        id: 'ai-agents',
+        name: 'AI Agents',
+      },
+      tldr: 'TL;DR: Visible tools help agents.',
+      excerpt:
+        'First paragraph that becomes a short excerpt for agent context.',
+      headings: [
+        { id: 'overview', title: 'Overview', level: 2 },
+        { id: 'details', title: 'Details', level: 4 },
+      ],
+    });
+  });
+
+  it('returns a structured miss when no content marker exists', () => {
+    document.body.innerHTML = '<main><p>Home page</p></main>';
+
+    expect(getCurrentContentContext(document)).toEqual({
+      ok: false,
+      error: '현재 페이지에는 WebMCP 콘텐츠 컨텍스트가 없습니다.',
+    });
+  });
+
+  it('reads code block text by zero-based index', () => {
+    expect(getCodeBlockText(0, document)).toEqual({
+      ok: true,
+      language: '',
+      text: 'const value = 1;',
+      characterCount: 16,
+    });
+    expect(getCodeBlockText(1, document)).toEqual({
+      ok: false,
+      error: '1번 코드 블록을 찾지 못했습니다.',
+    });
+  });
+
+  it('scrolls to a heading by id', () => {
+    const heading = document.getElementById('overview') as HTMLElement;
+    heading.scrollIntoView = vi.fn();
+
+    expect(jumpToHeading('overview', document)).toEqual({
+      ok: true,
+      headingId: 'overview',
+      title: 'Overview',
+    });
+    expect(heading.scrollIntoView).toHaveBeenCalledWith({
+      behavior: 'smooth',
+      block: 'start',
+    });
+  });
+
+  it('finds series target hrefs from marked links', () => {
+    expect(getSeriesTargetHref('series', document)).toEqual({
+      ok: true,
+      href: '/article/series/ai-agents',
+    });
+    expect(getSeriesTargetHref('next', document)).toEqual({
+      ok: false,
+      error: 'next 시리즈 이동 링크를 찾지 못했습니다.',
+    });
+  });
+
+  it('lists route-relevant page actions', () => {
+    expect(getPageActions('/article/agentic-interfaces', document)).toEqual([
+      'navigate_site',
+      'get_site_context',
+      'toggle_theme',
+      'set_sound',
+      'copy_current_url',
+      'find_content',
+      'open_content',
+      'list_page_actions',
+      'get_current_content_context',
+      'jump_to_heading',
+      'copy_code_block',
+      'open_series',
+    ]);
+  });
+});
+```
+
+- [ ] **Step 2: Run the failing snapshot test**
+
+Run:
+
+```bash
+pnpm test:unit src/components/webmcp/lib/content-snapshot.spec.ts
+```
+
+Expected: FAIL because `content-snapshot.ts` does not exist.
+
+- [ ] **Step 3: Implement the snapshot utilities**
+
+Create `src/components/webmcp/lib/content-snapshot.ts`:
+
+```ts
+import type { WebMCPToolName } from '@/components/webmcp/lib/schemas';
+
+type ContentType = 'article' | 'craft';
+type SeriesTarget = 'series' | 'previous' | 'next';
+
+type HeadingSnapshot = {
+  id: string;
+  title: string;
+  level: 2 | 4;
+};
+
+type SnapshotFailure = {
+  ok: false;
+  error: string;
+};
+
+const contentSelector = '[data-webmcp-content]';
+const codeBlockSelector = 'pre[data-webmcp-code-block]';
+
+const baseActions: WebMCPToolName[] = [
+  'navigate_site',
+  'get_site_context',
+  'toggle_theme',
+  'set_sound',
+  'copy_current_url',
+  'find_content',
+  'open_content',
+  'list_page_actions',
+];
+
+function cleanText(value: string | null | undefined) {
+  return value?.replace(/\s+/g, ' ').trim() ?? '';
+}
+
+function getDocument(doc: Document | undefined) {
+  return doc ?? document;
+}
+
+function getContentRoot(doc: Document) {
+  return doc.querySelector<HTMLElement>(contentSelector);
+}
+
+export function getCurrentContentContext(docLike?: Document) {
+  const doc = getDocument(docLike);
+  const root = getContentRoot(doc);
+
+  if (!root) {
+    return {
+      ok: false,
+      error: '현재 페이지에는 WebMCP 콘텐츠 컨텍스트가 없습니다.',
+    } satisfies SnapshotFailure;
+  }
+
+  const article = root.querySelector('article');
+  const headings = [
+    ...root.querySelectorAll<HTMLElement>('article h2[id], article h4[id]'),
+  ]
+    .map(heading => ({
+      id: heading.id,
+      title: cleanText(heading.textContent),
+      level: Number(heading.tagName.slice(1)) as 2 | 4,
+    }))
+    .filter((heading): heading is HeadingSnapshot =>
+      Boolean(heading.id && heading.title)
+    );
+  const excerpt = cleanText(article?.querySelector('p')?.textContent).slice(
+    0,
+    300
+  );
+  const seriesId = root.dataset.webmcpSeriesId;
+  const seriesName = root.dataset.webmcpSeriesName;
+
+  return {
+    ok: true,
+    type: root.dataset.webmcpContentType as ContentType,
+    slug: root.dataset.webmcpSlug ?? '',
+    title: root.dataset.webmcpTitle ?? '',
+    publishedAt: root.dataset.webmcpPublishedAt ?? '',
+    description: root.dataset.webmcpDescription ?? '',
+    summary: root.dataset.webmcpSummary ?? '',
+    ...(seriesId &&
+      seriesName && {
+        series: {
+          id: seriesId,
+          name: seriesName,
+        },
+      }),
+    tldr: cleanText(root.querySelector('blockquote')?.textContent),
+    excerpt,
+    headings,
+  };
+}
+
+export function getCodeBlockText(index: number, docLike?: Document) {
+  const doc = getDocument(docLike);
+  const block = [...doc.querySelectorAll<HTMLElement>(codeBlockSelector)][
+    index
+  ];
+  const code = block?.querySelector('code');
+  const text = code?.textContent?.trim() ?? '';
+
+  if (!block || !text) {
+    return {
+      ok: false,
+      error: `${index}번 코드 블록을 찾지 못했습니다.`,
+    } satisfies SnapshotFailure;
+  }
+
+  const languageClass = [...(code?.classList ?? [])].find(className =>
+    className.startsWith('language-')
+  );
+
+  return {
+    ok: true,
+    language: languageClass?.replace('language-', '') ?? '',
+    text,
+    characterCount: text.length,
+  };
+}
+
+export function jumpToHeading(headingId: string, docLike?: Document) {
+  const doc = getDocument(docLike);
+  const heading = doc.getElementById(headingId);
+
+  if (!heading) {
+    return {
+      ok: false,
+      error: `${headingId} heading을 찾지 못했습니다.`,
+    } satisfies SnapshotFailure;
+  }
+
+  heading.scrollIntoView({ behavior: 'smooth', block: 'start' });
+
+  return {
+    ok: true,
+    headingId,
+    title: cleanText(heading.textContent),
+  };
+}
+
+export function getSeriesTargetHref(target: SeriesTarget, docLike?: Document) {
+  const doc = getDocument(docLike);
+  const link = doc.querySelector<HTMLAnchorElement>(
+    `[data-webmcp-series-target="${target}"]`
+  );
+
+  if (!link) {
+    return {
+      ok: false,
+      error: `${target} 시리즈 이동 링크를 찾지 못했습니다.`,
+    } satisfies SnapshotFailure;
+  }
+
+  return {
+    ok: true,
+    href: link.getAttribute('href') ?? '',
+  };
+}
+
+export function getPageActions(pathname: string, docLike?: Document) {
+  const doc = getDocument(docLike);
+  const actions = new Set<WebMCPToolName>(baseActions);
+
+  if (getContentRoot(doc)) {
+    actions.add('get_current_content_context');
+    actions.add('jump_to_heading');
+  }
+
+  if (doc.querySelector(codeBlockSelector)) {
+    actions.add('copy_code_block');
+  }
+
+  if (doc.querySelector('[data-webmcp-series-target]')) {
+    actions.add('open_series');
+  }
+
+  if (pathname.startsWith('/playground/shuffle-letters')) {
+    actions.add('run_shuffle_letters');
+    actions.add('stop_shuffle_letters');
+  }
+
+  return [...actions];
+}
+```
+
+- [ ] **Step 4: Run the snapshot test**
+
+Run:
+
+```bash
+pnpm test:unit src/components/webmcp/lib/content-snapshot.spec.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Add content metadata markers to the MDX layout**
+
+Modify `src/components/layout/mdx.tsx`. Replace:
+
+```tsx
+<section id="BenddDoc">
+```
+
+with:
+
+```tsx
+<section
+  id="BenddDoc"
+  data-webmcp-content
+  data-webmcp-content-type={type}
+  data-webmcp-slug={post.slug}
+  data-webmcp-title={title}
+  data-webmcp-published-at={publishedAt}
+  data-webmcp-description={description}
+  data-webmcp-summary={summary}
+  data-webmcp-series-id={seriesInfo?.id}
+  data-webmcp-series-name={seriesInfo?.name}
+>
+```
+
+- [ ] **Step 6: Mark series navigation links**
+
+Modify `src/components/series/ui/series-navigation-top.tsx`. Add `data-webmcp-series-target="series"` to the series link:
+
+```tsx
+<Link
+  href={seriesRoute(id)}
+  data-webmcp-series-target="series"
+  className="mb-4 flex items-center gap-2 text-sm font-medium transition-colors hover:text-primary"
+>
+```
+
+Modify `src/components/series/ui/series-navigation-bottom.tsx`. Add `data-webmcp-series-target="series"` to the top series link:
+
+```tsx
+<Link
+  href={seriesRoute(id)}
+  data-webmcp-series-target="series"
+  className="mb-4 flex items-center gap-2 text-sm font-medium transition-colors hover:text-primary"
+>
+```
+
+In the previous link, add:
+
+```tsx
+data-webmcp-series-target="previous"
+```
+
+In the next link, add:
+
+```tsx
+data-webmcp-series-target="next"
+```
+
+- [ ] **Step 7: Mark MDX code blocks**
+
+Modify `src/mdx/components/pre/pre.tsx`. Add `data-webmcp-code-block` to the `<pre>` element:
+
+```tsx
+<pre
+  ref={preRef}
+  data-webmcp-code-block
+  className={cn(
+    'my-0 overflow-x-auto rounded-lg border border-solid border-border px-0 py-3',
+    'contrast-more:border-current contrast-more:dark:border-current'
+  )}
+  {...props}
+  tabIndex={-1}
+  translate="no"
+>
+```
+
+- [ ] **Step 8: Run related tests**
+
+Run:
+
+```bash
+pnpm test:unit src/components/webmcp/lib/content-snapshot.spec.ts src/components/series/test/series-navigation-top.spec.tsx src/components/series/test/series-navigation-bottom.spec.tsx
+```
+
+Expected: PASS.
+
+- [ ] **Step 9: Commit**
+
+Run:
+
+```bash
+git add src/components/webmcp/lib/content-snapshot.ts src/components/webmcp/lib/content-snapshot.spec.ts src/components/layout/mdx.tsx src/components/series/ui/series-navigation-top.tsx src/components/series/ui/series-navigation-bottom.tsx src/mdx/components/pre/pre.tsx
+git commit -m "feat(webmcp): 문서 스냅샷 마커 추가"
+```
+
+## Task 4: Tool Handlers
+
+**Files:**
+
+- Create: `src/components/webmcp/model/tool-handlers.ts`
+- Create: `src/components/webmcp/model/tool-handlers.spec.ts`
+- Modify: `src/components/sound/model/sound-store.ts`
+
+- [ ] **Step 1: Write failing handler tests**
+
+Create `src/components/webmcp/model/tool-handlers.spec.ts`:
+
+```ts
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import {
+  createLazyContentIndexFetcher,
+  createWebMCPHandlers,
+} from './tool-handlers';
+
+describe('createWebMCPHandlers', () => {
+  const push = vi.fn();
+  const setTheme = vi.fn();
+  const setSoundEnabled = vi.fn();
+  const writeText = vi.fn();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    document.body.innerHTML = `
+      <section
+        data-webmcp-content
+        data-webmcp-content-type="article"
+        data-webmcp-slug="agentic-interfaces"
+        data-webmcp-title="Agentic interfaces"
+        data-webmcp-published-at="2026-05-10"
+        data-webmcp-description="How agents use visible interfaces."
+        data-webmcp-summary="Agent UI notes"
+      >
+        <a href="/article/series/ai-agents" data-webmcp-series-target="series">Series</a>
+        <article>
+          <p>First paragraph.</p>
+          <h2 id="overview">Overview</h2>
+          <pre data-webmcp-code-block><code>const value = 1;</code></pre>
+        </article>
+      </section>
+    `;
+  });
+
+  function createHandlers() {
+    return createWebMCPHandlers({
+      pathname: '/article/agentic-interfaces',
+      router: { push },
+      getTheme: () => 'dark',
+      setTheme,
+      getSoundEnabled: () => false,
+      setSoundEnabled,
+      getCurrentHref: () => 'https://bendd.me/article/agentic-interfaces',
+      document,
+      clipboard: { writeText },
+      fetchContentIndex: async () => [
+        {
+          type: 'article',
+          slug: 'agentic-interfaces',
+          title: 'Agentic interfaces',
+          summary: 'Agent UI notes',
+          description: 'How agents use visible interfaces.',
+          publishedAt: '2026-05-10',
+          category: 'ai',
+          href: '/article/agentic-interfaces',
+        },
+      ],
+      dispatchWindowEvent: vi.fn(),
+    });
+  }
+
+  it('navigates only to known internal destinations', () => {
+    const handlers = createHandlers();
+
+    expect(handlers.navigateSite({ destination: 'craft' })).toEqual({
+      ok: true,
+      href: '/craft',
+    });
+    expect(push).toHaveBeenCalledWith('/craft');
+    expect(handlers.navigateSite({ destination: 'external' })).toEqual({
+      ok: false,
+      error: '지원하지 않는 destination입니다.',
+    });
+  });
+
+  it('toggles theme using the current resolved theme', () => {
+    const handlers = createHandlers();
+
+    expect(handlers.toggleTheme()).toEqual({
+      ok: true,
+      theme: 'light',
+    });
+    expect(setTheme).toHaveBeenCalledWith('light');
+  });
+
+  it('sets sound explicitly', () => {
+    const handlers = createHandlers();
+
+    expect(handlers.setSound({ enabled: true })).toEqual({
+      ok: true,
+      enabled: true,
+    });
+    expect(setSoundEnabled).toHaveBeenCalledWith(true);
+  });
+
+  it('searches the lazy content index', async () => {
+    const handlers = createHandlers();
+
+    await expect(
+      handlers.findContent({ query: 'agent', type: 'all', limit: 5 })
+    ).resolves.toEqual({
+      ok: true,
+      items: [
+        {
+          type: 'article',
+          slug: 'agentic-interfaces',
+          title: 'Agentic interfaces',
+          summary: 'Agent UI notes',
+          description: 'How agents use visible interfaces.',
+          publishedAt: '2026-05-10',
+          category: 'ai',
+          href: '/article/agentic-interfaces',
+        },
+      ],
+    });
+  });
+
+  it('copies code block text through the clipboard dependency', async () => {
+    const handlers = createHandlers();
+
+    await expect(handlers.copyCodeBlock({ index: 0 })).resolves.toEqual({
+      ok: true,
+      language: '',
+      characterCount: 16,
+    });
+    expect(writeText).toHaveBeenCalledWith('const value = 1;');
+  });
+
+  it('dispatches shuffle events after validating bounds', () => {
+    const dispatchWindowEvent = vi.fn();
+    const handlers = createWebMCPHandlers({
+      pathname: '/playground/shuffle-letters',
+      router: { push },
+      getTheme: () => 'light',
+      setTheme,
+      getSoundEnabled: () => false,
+      setSoundEnabled,
+      getCurrentHref: () => 'https://bendd.me/playground/shuffle-letters',
+      document,
+      clipboard: { writeText },
+      fetchContentIndex: async () => [],
+      dispatchWindowEvent,
+    });
+
+    expect(
+      handlers.runShuffleLetters({ text: 'Hello', iterations: 8, fps: 30 })
+    ).toEqual({
+      ok: true,
+      text: 'Hello',
+      iterations: 8,
+      fps: 30,
+    });
+    expect(dispatchWindowEvent).toHaveBeenCalledWith(
+      'webmcp:run-shuffle-letters',
+      { text: 'Hello', iterations: 8, fps: 30 }
+    );
+    expect(
+      handlers.runShuffleLetters({ text: 'Hello', iterations: 99, fps: 30 })
+    ).toEqual({
+      ok: false,
+      error: 'iterations는 1에서 50 사이여야 합니다.',
+    });
+  });
+});
+
+describe('createLazyContentIndexFetcher', () => {
+  it('fetches the index once and reuses the in-memory promise', async () => {
+    const fetcher = vi.fn(async () => ({
+      ok: true,
+      json: async () => ({ items: [{ slug: 'one' }] }),
+    })) as unknown as typeof fetch;
+
+    const load = createLazyContentIndexFetcher(fetcher);
+
+    await expect(load()).resolves.toEqual([{ slug: 'one' }]);
+    await expect(load()).resolves.toEqual([{ slug: 'one' }]);
+    expect(fetcher).toHaveBeenCalledTimes(1);
+  });
+});
+```
+
+- [ ] **Step 2: Run the failing handler test**
+
+Run:
+
+```bash
+pnpm test:unit src/components/webmcp/model/tool-handlers.spec.ts
+```
+
+Expected: FAIL because `tool-handlers.ts` does not exist.
+
+- [ ] **Step 3: Add explicit sound setter**
+
+Modify `src/components/sound/model/sound-store.ts`:
+
+```ts
+import { create } from 'zustand';
+import { persist } from 'zustand/middleware';
+
+type SoundState = {
+  isSoundEnabled: boolean;
+  toggleSoundEnabled: () => void;
+  setSoundEnabled: (enabled: boolean) => void;
+};
+
+export const useSoundStore = create<SoundState>()(
+  persist(
+    (set, get) => ({
+      isSoundEnabled: false,
+      toggleSoundEnabled: () => {
+        set({ isSoundEnabled: !get().isSoundEnabled });
+      },
+      setSoundEnabled: enabled => {
+        set({ isSoundEnabled: enabled });
+      },
+    }),
+    {
+      name: 'sound-enabled',
+    }
+  )
+);
+```
+
+- [ ] **Step 4: Implement the handler factory**
+
+Create `src/components/webmcp/model/tool-handlers.ts`:
+
+```ts
+import {
+  getCodeBlockText,
+  getCurrentContentContext,
+  getPageActions,
+  getSeriesTargetHref,
+  jumpToHeading,
+} from '@/components/webmcp/lib/content-snapshot';
+import type { WebMCPContentIndexItem } from '@/components/webmcp/lib/content-index';
+
+type RouterLike = {
+  push: (href: string) => void;
+};
+
+type ThemeValue = 'light' | 'dark' | 'system';
+
+type ClipboardLike = {
+  writeText: (text: string) => Promise<void>;
+};
+
+type ToolFailure = {
+  ok: false;
+  error: string;
+};
+
+type WebMCPHandlerDeps = {
+  pathname: string;
+  router: RouterLike;
+  getTheme: () => ThemeValue;
+  setTheme: (theme: 'light' | 'dark') => void;
+  getSoundEnabled: () => boolean;
+  setSoundEnabled: (enabled: boolean) => void;
+  getCurrentHref: () => string;
+  document: Document;
+  clipboard?: ClipboardLike;
+  fetchContentIndex: () => Promise<WebMCPContentIndexItem[]>;
+  dispatchWindowEvent: (name: string, detail?: unknown) => void;
+};
+
+const destinations = {
+  home: '/',
+  article: '/article',
+  craft: '/craft',
+  'shuffle-playground': '/playground/shuffle-letters',
+} as const;
+
+function isRecord(input: unknown): input is Record<string, unknown> {
+  return typeof input === 'object' && input !== null;
+}
+
+function fail(error: string): ToolFailure {
+  return { ok: false, error };
+}
+
+function readString(input: unknown, key: string) {
+  if (!isRecord(input) || typeof input[key] !== 'string') {
+    return undefined;
+  }
+
+  return input[key];
+}
+
+function readNumber(input: unknown, key: string) {
+  if (!isRecord(input) || typeof input[key] !== 'number') {
+    return undefined;
+  }
+
+  return input[key];
+}
+
+function readBoolean(input: unknown, key: string) {
+  if (!isRecord(input) || typeof input[key] !== 'boolean') {
+    return undefined;
+  }
+
+  return input[key];
+}
+
+function includesText(item: WebMCPContentIndexItem, query: string) {
+  const haystack = [
+    item.title,
+    item.summary,
+    item.description,
+    item.category,
+    item.slug,
+    item.series?.name ?? '',
+  ]
+    .join(' ')
+    .toLowerCase();
+
+  return haystack.includes(query.toLowerCase());
+}
+
+export function createLazyContentIndexFetcher(fetcher: typeof fetch = fetch) {
+  let cached: Promise<WebMCPContentIndexItem[]> | undefined;
+
+  return async () => {
+    cached ??= fetcher('/api/webmcp/content-index')
+      .then(response => {
+        if (!response.ok) {
+          throw new Error('WebMCP 콘텐츠 인덱스를 불러오지 못했습니다.');
+        }
+
+        return response.json();
+      })
+      .then((body: { items?: WebMCPContentIndexItem[] }) => body.items ?? []);
+
+    return cached;
+  };
+}
+
+export function createWebMCPHandlers(deps: WebMCPHandlerDeps) {
+  return {
+    navigateSite(input: unknown) {
+      const destination = readString(input, 'destination');
+      const href = destination
+        ? destinations[destination as keyof typeof destinations]
+        : undefined;
+
+      if (!href) {
+        return fail('지원하지 않는 destination입니다.');
+      }
+
+      deps.router.push(href);
+      return { ok: true, href };
+    },
+
+    getSiteContext() {
+      return {
+        ok: true,
+        pathname: deps.pathname,
+        title: deps.document.title,
+        canonicalUrl:
+          deps.document.querySelector<HTMLLinkElement>('link[rel="canonical"]')
+            ?.href ?? deps.getCurrentHref(),
+        actions: getPageActions(deps.pathname, deps.document),
+      };
+    },
+
+    toggleTheme() {
+      const nextTheme = deps.getTheme() === 'dark' ? 'light' : 'dark';
+      deps.setTheme(nextTheme);
+      return { ok: true, theme: nextTheme };
+    },
+
+    setSound(input: unknown) {
+      const enabled = readBoolean(input, 'enabled');
+
+      if (enabled == null) {
+        return fail('enabled boolean 값이 필요합니다.');
+      }
+
+      deps.setSoundEnabled(enabled);
+      return { ok: true, enabled };
+    },
+
+    async copyCurrentUrl() {
+      const href = deps.getCurrentHref();
+
+      if (!deps.clipboard) {
+        return fail('클립보드 API를 사용할 수 없습니다.');
+      }
+
+      await deps.clipboard.writeText(href);
+      return { ok: true, href };
+    },
+
+    async findContent(input: unknown) {
+      const query = readString(input, 'query')?.trim();
+      const type = readString(input, 'type') ?? 'all';
+      const limit = readNumber(input, 'limit') ?? 5;
+
+      if (!query) {
+        return fail('query 문자열이 필요합니다.');
+      }
+
+      if (!['all', 'article', 'craft'].includes(type)) {
+        return fail('type은 all, article, craft 중 하나여야 합니다.');
+      }
+
+      if (limit < 1 || limit > 10) {
+        return fail('limit은 1에서 10 사이여야 합니다.');
+      }
+
+      const items = await deps.fetchContentIndex();
+      return {
+        ok: true,
+        items: items
+          .filter(item => type === 'all' || item.type === type)
+          .filter(item => includesText(item, query))
+          .slice(0, limit),
+      };
+    },
+
+    async openContent(input: unknown) {
+      const type = readString(input, 'type');
+      const slug = readString(input, 'slug');
+
+      if (type !== 'article' && type !== 'craft') {
+        return fail('type은 article 또는 craft여야 합니다.');
+      }
+
+      if (!slug) {
+        return fail('slug 문자열이 필요합니다.');
+      }
+
+      const items = await deps.fetchContentIndex();
+      const target = items.find(
+        item => item.type === type && item.slug === slug
+      );
+
+      if (!target) {
+        return fail(`${type}/${slug} 콘텐츠를 찾지 못했습니다.`);
+      }
+
+      deps.router.push(target.href);
+      return { ok: true, href: target.href };
+    },
+
+    getCurrentContentContext() {
+      return getCurrentContentContext(deps.document);
+    },
+
+    openSeries(input: unknown) {
+      const target = readString(input, 'target');
+
+      if (target !== 'series' && target !== 'previous' && target !== 'next') {
+        return fail('target은 series, previous, next 중 하나여야 합니다.');
+      }
+
+      const result = getSeriesTargetHref(target, deps.document);
+
+      if (!result.ok) {
+        return result;
+      }
+
+      deps.router.push(result.href);
+      return { ok: true, href: result.href };
+    },
+
+    jumpToHeading(input: unknown) {
+      const headingId = readString(input, 'headingId');
+
+      if (!headingId) {
+        return fail('headingId 문자열이 필요합니다.');
+      }
+
+      return jumpToHeading(headingId, deps.document);
+    },
+
+    async copyCodeBlock(input: unknown) {
+      const index = readNumber(input, 'index');
+
+      if (index == null || index < 0) {
+        return fail('index는 0 이상의 숫자여야 합니다.');
+      }
+
+      const result = getCodeBlockText(index, deps.document);
+
+      if (!result.ok) {
+        return result;
+      }
+
+      if (!deps.clipboard) {
+        return fail('클립보드 API를 사용할 수 없습니다.');
+      }
+
+      await deps.clipboard.writeText(result.text);
+      return {
+        ok: true,
+        language: result.language,
+        characterCount: result.characterCount,
+      };
+    },
+
+    listPageActions() {
+      return {
+        ok: true,
+        actions: getPageActions(deps.pathname, deps.document),
+      };
+    },
+
+    runShuffleLetters(input: unknown) {
+      const text = readString(input, 'text')?.trim();
+      const iterations = readNumber(input, 'iterations');
+      const fps = readNumber(input, 'fps');
+
+      if (!text) {
+        return fail('text 문자열이 필요합니다.');
+      }
+
+      if (iterations == null || iterations < 1 || iterations > 50) {
+        return fail('iterations는 1에서 50 사이여야 합니다.');
+      }
+
+      if (fps == null || fps < 1 || fps > 60) {
+        return fail('fps는 1에서 60 사이여야 합니다.');
+      }
+
+      deps.dispatchWindowEvent('webmcp:run-shuffle-letters', {
+        text,
+        iterations,
+        fps,
+      });
+
+      return { ok: true, text, iterations, fps };
+    },
+
+    stopShuffleLetters() {
+      deps.dispatchWindowEvent('webmcp:stop-shuffle-letters');
+      return { ok: true };
+    },
+  };
+}
+```
+
+- [ ] **Step 5: Run handler tests**
+
+Run:
+
+```bash
+pnpm test:unit src/components/webmcp/model/tool-handlers.spec.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Run sound switcher test**
+
+Run:
+
+```bash
+pnpm test:unit src/components/sound/ui/sound-switcher.spec.tsx
+```
+
+Expected: PASS.
+
+- [ ] **Step 7: Commit**
+
+Run:
+
+```bash
+git add src/components/webmcp/model/tool-handlers.ts src/components/webmcp/model/tool-handlers.spec.ts src/components/sound/model/sound-store.ts
+git commit -m "feat(webmcp): 에이전트 도구 핸들러 추가"
+```
+
+## Task 5: Provider Lifecycle and Root Layout Integration
+
+**Files:**
+
+- Create: `src/components/webmcp/model/use-webmcp-tools.ts`
+- Create: `src/components/webmcp/ui/webmcp-provider.tsx`
+- Create: `src/components/webmcp/ui/webmcp-provider.spec.tsx`
+- Create: `src/components/webmcp/index.ts`
+- Modify: `src/app/layout.tsx`
+
+- [ ] **Step 1: Write failing provider lifecycle tests**
+
+Create `src/components/webmcp/ui/webmcp-provider.spec.tsx`:
+
+```tsx
+import { render } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('@/components/webmcp/model/use-webmcp-tools', () => ({
+  useWebMCPTools: () => [
+    {
+      name: 'get_site_context',
+      description: 'Read site context.',
+      inputSchema: {
+        type: 'object',
+        properties: {},
+        additionalProperties: false,
+      },
+      execute: vi.fn(),
+    },
+  ],
+}));
+
+import { WebMCPProvider } from './webmcp-provider';
+
+describe('WebMCPProvider', () => {
+  let originalNavigatorDescriptor: PropertyDescriptor | undefined;
+  let originalRequestIdleCallback: typeof globalThis.requestIdleCallback;
+  let originalCancelIdleCallback: typeof globalThis.cancelIdleCallback;
+
+  beforeEach(() => {
+    originalNavigatorDescriptor = Object.getOwnPropertyDescriptor(
+      globalThis,
+      'navigator'
+    );
+    originalRequestIdleCallback = globalThis.requestIdleCallback;
+    originalCancelIdleCallback = globalThis.cancelIdleCallback;
+  });
+
+  afterEach(() => {
+    if (originalNavigatorDescriptor) {
+      Object.defineProperty(
+        globalThis,
+        'navigator',
+        originalNavigatorDescriptor
+      );
+    }
+    globalThis.requestIdleCallback = originalRequestIdleCallback;
+    globalThis.cancelIdleCallback = originalCancelIdleCallback;
+    vi.clearAllMocks();
+  });
+
+  it('does not schedule idle work when WebMCP is unsupported', () => {
+    const idle = vi.fn();
+    globalThis.requestIdleCallback = idle as typeof requestIdleCallback;
+    Object.defineProperty(globalThis, 'navigator', {
+      configurable: true,
+      value: {},
+    });
+
+    render(<WebMCPProvider />);
+
+    expect(idle).not.toHaveBeenCalled();
+  });
+
+  it('registers tools during idle time and aborts on unmount', () => {
+    const registerTool = vi.fn();
+    const idleCallbacks: IdleRequestCallback[] = [];
+    globalThis.requestIdleCallback = vi.fn((callback: IdleRequestCallback) => {
+      idleCallbacks.push(callback);
+      return idleCallbacks.length;
+    }) as typeof requestIdleCallback;
+    globalThis.cancelIdleCallback = vi.fn() as typeof cancelIdleCallback;
+    Object.defineProperty(globalThis, 'navigator', {
+      configurable: true,
+      value: {
+        modelContext: { registerTool },
+      },
+    });
+
+    const { unmount } = render(<WebMCPProvider />);
+
+    expect(registerTool).not.toHaveBeenCalled();
+    idleCallbacks[0]({} as IdleDeadline);
+    expect(registerTool).toHaveBeenCalledTimes(1);
+
+    const signal = registerTool.mock.calls[0][1].signal as AbortSignal;
+    expect(signal.aborted).toBe(false);
+
+    unmount();
+
+    expect(signal.aborted).toBe(true);
+  });
+});
+```
+
+- [ ] **Step 2: Run the failing provider test**
+
+Run:
+
+```bash
+pnpm test:unit src/components/webmcp/ui/webmcp-provider.spec.tsx
+```
+
+Expected: FAIL because `webmcp-provider.tsx` does not exist.
+
+- [ ] **Step 3: Implement the WebMCP tool hook**
+
+Create `src/components/webmcp/model/use-webmcp-tools.ts`:
+
+```ts
+'use client';
+
+import { useTheme } from 'next-themes';
+import { usePathname, useRouter } from 'next/navigation';
+import { useMemo } from 'react';
+
+import {
+  emptyObjectSchema,
+  createToolDescriptor,
+  webMCPSchemas,
+} from '@/components/webmcp/lib/schemas';
+import {
+  createLazyContentIndexFetcher,
+  createWebMCPHandlers,
+} from '@/components/webmcp/model/tool-handlers';
+import { useSoundStore } from '@/components/sound';
+
+const fetchContentIndex = createLazyContentIndexFetcher();
+
+export function useWebMCPTools() {
+  const pathname = usePathname();
+  const router = useRouter();
+  const { resolvedTheme, setTheme } = useTheme();
+  const isSoundEnabled = useSoundStore(state => state.isSoundEnabled);
+  const setSoundEnabled = useSoundStore(state => state.setSoundEnabled);
+
+  return useMemo(() => {
+    const handlers = createWebMCPHandlers({
+      pathname,
+      router,
+      getTheme: () => (resolvedTheme === 'dark' ? 'dark' : 'light'),
+      setTheme,
+      getSoundEnabled: () => isSoundEnabled,
+      setSoundEnabled,
+      getCurrentHref: () => window.location.href,
+      document,
+      clipboard: navigator.clipboard,
+      fetchContentIndex,
+      dispatchWindowEvent: (name, detail) => {
+        window.dispatchEvent(new CustomEvent(name, { detail }));
+      },
+    });
+
+    const tools = [
+      createToolDescriptor({
+        name: 'navigate_site',
+        description: 'Navigate to a safe internal page on bendd.me.',
+        inputSchema: webMCPSchemas.navigateSite,
+        execute: handlers.navigateSite,
+      }),
+      createToolDescriptor({
+        name: 'get_site_context',
+        description:
+          'Read the current bendd.me route, title, canonical URL, and available actions.',
+        inputSchema: emptyObjectSchema,
+        annotations: { readOnlyHint: true },
+        execute: handlers.getSiteContext,
+      }),
+      createToolDescriptor({
+        name: 'toggle_theme',
+        description: 'Toggle the visible site theme between light and dark.',
+        inputSchema: emptyObjectSchema,
+        execute: handlers.toggleTheme,
+      }),
+      createToolDescriptor({
+        name: 'set_sound',
+        description: 'Enable or disable site interaction sounds.',
+        inputSchema: webMCPSchemas.setSound,
+        execute: handlers.setSound,
+      }),
+      createToolDescriptor({
+        name: 'copy_current_url',
+        description: 'Copy the current page URL to the clipboard.',
+        inputSchema: emptyObjectSchema,
+        execute: handlers.copyCurrentUrl,
+      }),
+      createToolDescriptor({
+        name: 'find_content',
+        description:
+          'Search bendd.me article and craft metadata by title, summary, description, category, slug, or series.',
+        inputSchema: webMCPSchemas.findContent,
+        annotations: { readOnlyHint: true },
+        execute: handlers.findContent,
+      }),
+      createToolDescriptor({
+        name: 'open_content',
+        description: 'Open an internal article or craft page by type and slug.',
+        inputSchema: webMCPSchemas.openContent,
+        execute: handlers.openContent,
+      }),
+      createToolDescriptor({
+        name: 'get_current_content_context',
+        description:
+          'Read the current article or craft title, metadata, TL;DR, headings, and a short excerpt.',
+        inputSchema: emptyObjectSchema,
+        annotations: { readOnlyHint: true },
+        execute: handlers.getCurrentContentContext,
+      }),
+      createToolDescriptor({
+        name: 'open_series',
+        description:
+          'Open the current series page, previous article, or next article when available.',
+        inputSchema: webMCPSchemas.openSeries,
+        execute: handlers.openSeries,
+      }),
+      createToolDescriptor({
+        name: 'jump_to_heading',
+        description:
+          'Scroll the current article or craft page to a heading by id.',
+        inputSchema: webMCPSchemas.jumpToHeading,
+        execute: handlers.jumpToHeading,
+      }),
+      createToolDescriptor({
+        name: 'copy_code_block',
+        description: 'Copy a visible MDX code block by zero-based index.',
+        inputSchema: webMCPSchemas.copyCodeBlock,
+        execute: handlers.copyCodeBlock,
+      }),
+      createToolDescriptor({
+        name: 'list_page_actions',
+        description:
+          'List the WebMCP actions that are meaningful on the current route.',
+        inputSchema: emptyObjectSchema,
+        annotations: { readOnlyHint: true },
+        execute: handlers.listPageActions,
+      }),
+      createToolDescriptor({
+        name: 'run_shuffle_letters',
+        description:
+          'Fill and run the shuffle letters playground with visible values.',
+        inputSchema: webMCPSchemas.runShuffleLetters,
+        execute: handlers.runShuffleLetters,
+      }),
+      createToolDescriptor({
+        name: 'stop_shuffle_letters',
+        description: 'Stop the running shuffle letters animation.',
+        inputSchema: emptyObjectSchema,
+        execute: handlers.stopShuffleLetters,
+      }),
+    ];
+
+    const available = new Set(handlers.listPageActions().actions);
+    return tools.filter(tool => available.has(tool.name));
+  }, [
+    isSoundEnabled,
+    pathname,
+    resolvedTheme,
+    router,
+    setSoundEnabled,
+    setTheme,
+  ]);
+}
+```
+
+- [ ] **Step 4: Implement the provider**
+
+Create `src/components/webmcp/ui/webmcp-provider.tsx`:
+
+```tsx
+'use client';
+
+import { useEffect } from 'react';
+
+import {
+  hasModelContext,
+  registerWebMCPTools,
+} from '@/components/webmcp/lib/register-tool';
+import { useWebMCPTools } from '@/components/webmcp/model/use-webmcp-tools';
+
+export function WebMCPProvider() {
+  const tools = useWebMCPTools();
+
+  useEffect(() => {
+    if (!hasModelContext()) {
+      return;
+    }
+
+    let cleanup = () => {};
+    const requestIdle =
+      globalThis.requestIdleCallback ??
+      ((callback: IdleRequestCallback) =>
+        window.setTimeout(() => callback({} as IdleDeadline), 0));
+    const cancelIdle = globalThis.cancelIdleCallback ?? window.clearTimeout;
+
+    const idleId = requestIdle(() => {
+      cleanup = registerWebMCPTools(tools);
+    });
+
+    return () => {
+      cancelIdle(idleId);
+      cleanup();
+    };
+  }, [tools]);
+
+  return null;
+}
+```
+
+- [ ] **Step 5: Dynamically mount the provider in root layout**
+
+Create `src/components/webmcp/index.ts`:
+
+```ts
+export { WebMCPProvider } from './ui/webmcp-provider';
+```
+
+Modify `src/app/layout.tsx`. Add this dynamic import near the existing dynamic imports:
+
+```tsx
+const WebMCPProvider = dynamic(
+  () => import('@/components/webmcp').then(mod => mod.WebMCPProvider),
+  {
+    ssr: false,
+  }
+);
+```
+
+Inside `<ThemeProvider>`, place the provider before the visible app UI:
+
+```tsx
+<ThemeProvider
+  attribute="class"
+  defaultTheme="system"
+  storageKey="theme"
+  enableSystem
+  disableTransitionOnChange
+>
+  <WebMCPProvider />
+  <TooltipProvider>
+    <Signature />
+    {children}
+```
+
+- [ ] **Step 6: Run provider and type checks**
+
+Run:
+
+```bash
+pnpm test:unit src/components/webmcp/ui/webmcp-provider.spec.tsx
+pnpm check-types
+```
+
+Expected: PASS for both commands.
+
+- [ ] **Step 7: Commit**
+
+Run:
+
+```bash
+git add src/components/webmcp/model/use-webmcp-tools.ts src/components/webmcp/ui/webmcp-provider.tsx src/components/webmcp/ui/webmcp-provider.spec.tsx src/components/webmcp/index.ts src/app/layout.tsx
+git commit -m "feat(webmcp): provider 연결 및 route별 도구 등록"
+```
+
+## Task 6: Shuffle Letters Declarative and Imperative Execution
+
+**Files:**
+
+- Modify: `src/mdx/components/shuffle-letters-demo/shuffle-letters-demo.tsx`
+- Modify: `src/app/playground/shuffle-letters/page.tsx`
+- Create: `src/mdx/components/shuffle-letters-demo/shuffle-letters-demo.spec.tsx`
+
+- [ ] **Step 1: Write failing MDX shuffle tests**
+
+Create `src/mdx/components/shuffle-letters-demo/shuffle-letters-demo.spec.tsx`:
+
+```tsx
+import { fireEvent, render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('@/components/article/lib/shuffle-letters', () => ({
+  shuffleLetters: vi.fn((_element, options) => {
+    options?.onComplete?.();
+    return vi.fn();
+  }),
+}));
+
+import { shuffleLetters } from '@/components/article/lib/shuffle-letters';
+import { MDXShuffleLettersDemo } from './shuffle-letters-demo';
+
+describe('MDXShuffleLettersDemo WebMCP integration', () => {
+  it('exposes declarative WebMCP form annotations', () => {
+    render(<MDXShuffleLettersDemo />);
+
+    const form = screen.getByRole('form', {
+      name: 'Shuffle letters playground',
+    });
+
+    expect(form).toHaveAttribute('toolname', 'run_shuffle_letters');
+    expect(form).toHaveAttribute('toolautosubmit');
+    expect(screen.getByLabelText('텍스트')).toHaveAttribute(
+      'toolparamdescription',
+      'Text to animate with the shuffle letters effect.'
+    );
+  });
+
+  it('runs visible animation when the WebMCP custom event is dispatched', () => {
+    render(<MDXShuffleLettersDemo />);
+
+    window.dispatchEvent(
+      new CustomEvent('webmcp:run-shuffle-letters', {
+        detail: {
+          text: 'Agent text',
+          iterations: 9,
+          fps: 24,
+        },
+      })
+    );
+
+    expect(screen.getByDisplayValue('Agent text')).toBeTruthy();
+    expect(shuffleLetters).toHaveBeenCalledWith(
+      expect.any(HTMLDivElement),
+      expect.objectContaining({
+        iterations: 9,
+        fps: 24,
+      })
+    );
+  });
+});
+```
+
+- [ ] **Step 2: Run the failing MDX shuffle test**
+
+Run:
+
+```bash
+pnpm test:unit src/mdx/components/shuffle-letters-demo/shuffle-letters-demo.spec.tsx
+```
+
+Expected: FAIL because the form has no WebMCP annotations and no event listener.
+
+- [ ] **Step 3: Refactor MDX shuffle start logic**
+
+Modify `src/mdx/components/shuffle-letters-demo/shuffle-letters-demo.tsx`. Add this type near the props type:
+
+```ts
+type ShuffleLettersPayload = {
+  text: string;
+  iterations: number;
+  fps: number;
+};
+
+type AgentSubmitEvent = SubmitEvent & {
+  agentInvoked?: boolean;
+  respondWith?: (promise: Promise<unknown>) => void;
+};
+```
+
+Replace the existing `handleSubmit` with `startAnimation` plus `handleSubmit`:
+
+```ts
+const startAnimation = useCallback(
+  ({
+    text: nextText,
+    iterations: nextIterations,
+    fps: nextFps,
+  }: ShuffleLettersPayload) => {
+    if (isAnimating || !animatedTextRef.current) return false;
+
+    setText(nextText);
+    setIterations(nextIterations);
+    setFps(nextFps);
+    animatedTextRef.current.textContent = nextText;
+    setIsAnimating(true);
+    clearAnimationRef.current = shuffleLetters(animatedTextRef.current, {
+      iterations: nextIterations,
+      fps: nextFps,
+      onComplete: () => {
+        setIsAnimating(false);
+        clearAnimationRef.current = null;
+      },
+    });
+
+    return true;
+  },
+  [isAnimating]
+);
+
+const handleSubmit = (e: React.FormEvent<HTMLFormElement>) => {
+  e.preventDefault();
+  const started = startAnimation({ text, iterations, fps });
+  const nativeEvent = e.nativeEvent as AgentSubmitEvent;
+
+  if (nativeEvent.agentInvoked && nativeEvent.respondWith) {
+    nativeEvent.respondWith(
+      Promise.resolve({
+        ok: started,
+        text,
+        iterations,
+        fps,
+      })
+    );
+  }
+};
+```
+
+Add this event effect below the Escape-key effect:
+
+```ts
+useEffect(() => {
+  const handleRun = (event: Event) => {
+    const { detail } = event as CustomEvent<ShuffleLettersPayload>;
+    if (!detail) return;
+    startAnimation(detail);
+  };
+
+  const handleStop = () => {
+    stopAnimation();
+  };
+
+  window.addEventListener('webmcp:run-shuffle-letters', handleRun);
+  window.addEventListener('webmcp:stop-shuffle-letters', handleStop);
+
+  return () => {
+    window.removeEventListener('webmcp:run-shuffle-letters', handleRun);
+    window.removeEventListener('webmcp:stop-shuffle-letters', handleStop);
+  };
+}, [startAnimation, stopAnimation]);
+```
+
+- [ ] **Step 4: Add declarative attributes to the MDX form and inputs**
+
+In `src/mdx/components/shuffle-letters-demo/shuffle-letters-demo.tsx`, change the form opening tag to:
+
+```tsx
+<form
+  aria-label="Shuffle letters playground"
+  toolname="run_shuffle_letters"
+  tooldescription="Runs the shuffle letters animation with visible form values."
+  toolautosubmit
+  onSubmit={handleSubmit}
+  className="w-full max-w-md space-y-4"
+>
+```
+
+Add `name` and `toolparamdescription` to the text input:
+
+```tsx
+<Input
+  id="text"
+  name="text"
+  type="text"
+  value={text || ''}
+  onChange={e => setText(e.target.value)}
+  toolparamdescription="Text to animate with the shuffle letters effect."
+  required
+/>
+```
+
+Add `name` and `toolparamdescription` to the iterations input:
+
+```tsx
+<Input
+  id="iterations"
+  name="iterations"
+  type="number"
+  value={iterations}
+  onChange={e => setIterations(Number(e.target.value))}
+  min="1"
+  max="50"
+  toolparamdescription="Number of random character replacements per letter. Use 1 through 50."
+  required
+/>
+```
+
+Add `name` and `toolparamdescription` to the fps input:
+
+```tsx
+<Input
+  id="fps"
+  name="fps"
+  type="number"
+  value={fps}
+  onChange={e => setFps(Number(e.target.value))}
+  min="1"
+  max="60"
+  toolparamdescription="Animation frames per second. Use 1 through 60."
+  required
+/>
+```
+
+- [ ] **Step 5: Add WebMCP execution to the standalone playground**
+
+Modify `src/app/playground/shuffle-letters/page.tsx`. Add these types below the imports:
+
+```ts
+type ShuffleLettersPayload = {
+  text: string;
+  iterations: number;
+  fps: number;
+};
+
+type AgentSubmitEvent = SubmitEvent & {
+  agentInvoked?: boolean;
+  respondWith?: (promise: Promise<unknown>) => void;
+};
+```
+
+Replace the existing `handleSubmit` with this `startAnimation` and `handleSubmit` pair:
+
+```ts
+const startAnimation = useCallback(
+  ({
+    text: nextText,
+    iterations: nextIterations,
+    fps: nextFps,
+  }: ShuffleLettersPayload) => {
+    if (isAnimating || !animatedTextRef.current) return false;
+
+    setText(nextText);
+    setIterations(nextIterations);
+    setFps(nextFps);
+    animatedTextRef.current.textContent = nextText;
+    setIsAnimating(true);
+    clearAnimationRef.current = shuffleLetters(animatedTextRef.current, {
+      iterations: nextIterations,
+      fps: nextFps,
+      onComplete: () => {
+        setIsAnimating(false);
+        clearAnimationRef.current = null;
+      },
+    });
+
+    return true;
+  },
+  [isAnimating]
+);
+
+const handleSubmit = (e: React.FormEvent<HTMLFormElement>) => {
+  e.preventDefault();
+  const started = startAnimation({ text, iterations, fps });
+  const nativeEvent = e.nativeEvent as AgentSubmitEvent;
+
+  if (nativeEvent.agentInvoked && nativeEvent.respondWith) {
+    nativeEvent.respondWith(
+      Promise.resolve({
+        ok: started,
+        text,
+        iterations,
+        fps,
+      })
+    );
+  }
+};
+```
+
+Add this effect below the existing Escape-key effect:
+
+```ts
+useEffect(() => {
+  const handleRun = (event: Event) => {
+    const { detail } = event as CustomEvent<ShuffleLettersPayload>;
+    if (!detail) return;
+    startAnimation(detail);
+  };
+
+  const handleStop = () => {
+    stopAnimation();
+  };
+
+  window.addEventListener('webmcp:run-shuffle-letters', handleRun);
+  window.addEventListener('webmcp:stop-shuffle-letters', handleStop);
+
+  return () => {
+    window.removeEventListener('webmcp:run-shuffle-letters', handleRun);
+    window.removeEventListener('webmcp:stop-shuffle-letters', handleStop);
+  };
+}, [startAnimation, stopAnimation]);
+```
+
+Change the standalone form opening tag to:
+
+```tsx
+<form
+  aria-label="Shuffle letters playground"
+  toolname="run_shuffle_letters"
+  tooldescription="Runs the shuffle letters animation with visible form values."
+  toolautosubmit
+  onSubmit={handleSubmit}
+  className="w-full max-w-md rounded-lg p-6 shadow-md"
+>
+```
+
+Change the standalone text input to include `name` and `toolparamdescription`:
+
+```tsx
+<input
+  id="text"
+  name="text"
+  type="text"
+  value={text}
+  onChange={e => setText(e.target.value)}
+  toolparamdescription="Text to animate with the shuffle letters effect."
+  className="w-full rounded-md border border-input px-3 py-2"
+  required
+/>
+```
+
+Change the standalone iterations input to include `name` and `toolparamdescription`:
+
+```tsx
+<input
+  id="iterations"
+  name="iterations"
+  type="number"
+  value={iterations}
+  onChange={e => setIterations(Number(e.target.value))}
+  min="1"
+  max="50"
+  toolparamdescription="Number of random character replacements per letter. Use 1 through 50."
+  className="w-full rounded-md border border-input px-3 py-2"
+  required
+/>
+```
+
+Change the standalone fps input to include `name` and `toolparamdescription`:
+
+```tsx
+<input
+  id="fps"
+  name="fps"
+  type="number"
+  value={fps}
+  onChange={e => setFps(Number(e.target.value))}
+  min="1"
+  max="60"
+  toolparamdescription="Animation frames per second. Use 1 through 60."
+  className="w-full rounded-md border border-input px-3 py-2"
+  required
+/>
+```
+
+- [ ] **Step 6: Run shuffle tests**
+
+Run:
+
+```bash
+pnpm test:unit src/mdx/components/shuffle-letters-demo/shuffle-letters-demo.spec.tsx
+```
+
+Expected: PASS.
+
+- [ ] **Step 7: Commit**
+
+Run:
+
+```bash
+git add src/mdx/components/shuffle-letters-demo/shuffle-letters-demo.tsx src/app/playground/shuffle-letters/page.tsx src/mdx/components/shuffle-letters-demo/shuffle-letters-demo.spec.tsx
+git commit -m "feat(webmcp): shuffle letters 도구 실행 지원"
+```
+
+## Task 7: Permissions Policy, Focus Styles, and Project Docs
+
+**Files:**
+
+- Modify: `next.config.mjs`
+- Modify: `src/globals.css`
+- Modify: `docs/architecture.md`
+- Modify: `docs/conventions.md`
+
+- [ ] **Step 1: Update Permissions-Policy**
+
+Modify the `Permissions-Policy` header in `next.config.mjs` from:
+
+```js
+{
+  key: 'Permissions-Policy',
+  value: 'camera=(), microphone=(), geolocation=()',
+},
+```
+
+to:
+
+```js
+{
+  key: 'Permissions-Policy',
+  value: 'camera=(), microphone=(), geolocation=(), tools=(self)',
+},
+```
+
+- [ ] **Step 2: Add WebMCP focus styles**
+
+Add this block inside `@layer base` in `src/globals.css`, near the existing `.header-anchor` rule:
+
+```css
+form:tool-form-active {
+  outline: hsl(var(--ring)) dashed 1px;
+  outline-offset: 4px;
+}
+
+button:tool-submit-active {
+  outline: hsl(var(--primary)) dashed 1px;
+  outline-offset: 2px;
+}
+```
+
+- [ ] **Step 3: Document architecture**
+
+Append this section to `docs/architecture.md`:
+
+```md
+## WebMCP
+
+WebMCP is implemented as a progressive enhancement. The root layout dynamically
+mounts `WebMCPProvider` with `ssr: false`, and the provider exits immediately
+unless the browser exposes `navigator.modelContext`.
+
+The provider registers route-relevant tools only during idle time and aborts
+the previous registration on route changes. Content search does not build a
+global index during page load. It fetches `/api/webmcp/content-index` only when
+the `find_content` tool runs, then reuses the in-memory result for the current
+browser session.
+
+The WebMCP surface is intentionally limited to safe visible actions:
+
+- internal navigation
+- content metadata search
+- current article/craft context snippets
+- heading scroll
+- code block copy
+- theme and sound settings
+- shuffle letters playground execution
+
+External links and `mailto:` links are not opened automatically by WebMCP tools.
+Cross-origin iframes do not receive `allow="tools"`.
+```
+
+- [ ] **Step 4: Document conventions**
+
+Append this section to `docs/conventions.md`:
+
+```md
+## WebMCP
+
+WebMCP code lives under `src/components/webmcp/` and follows the domain
+component barrel export rule. Import it as `@/components/webmcp`.
+
+Rules:
+
+- Always feature-detect `navigator.modelContext` before creating schemas,
+  scanning DOM, or registering tools.
+- Register tools during idle time through `registerWebMCPTools`.
+- Use `AbortController` cleanup for every registration lifecycle.
+- Keep tool outputs small. Article and craft tools may return metadata,
+  TL;DR, headings, and short excerpts, but not full MDX bodies.
+- Keep external navigation manual. WebMCP tools may return external URLs but
+  must not automatically open them.
+- Add declarative attributes only to real forms with visible user-facing
+  controls.
+- Use HSL CSS variables for `:tool-form-active` and `:tool-submit-active`
+  styles.
+```
+
+- [ ] **Step 5: Run static checks**
+
+Run:
+
+```bash
+pnpm check-types
+pnpm lint
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+Run:
+
+```bash
+git add next.config.mjs src/globals.css docs/architecture.md docs/conventions.md
+git commit -m "docs(webmcp): 적용 규칙과 권한 정책 문서화"
+```
+
+## Task 8: Final Verification
+
+**Files:**
+
+- Review: all files changed by Tasks 1 through 7
+
+- [ ] **Step 1: Run WebMCP unit tests**
+
+Run:
+
+```bash
+pnpm test:unit src/components/webmcp/lib/register-tool.spec.ts src/components/webmcp/lib/content-index.spec.ts src/app/api/webmcp/content-index/route.spec.ts src/components/webmcp/lib/content-snapshot.spec.ts src/components/webmcp/model/tool-handlers.spec.ts src/components/webmcp/ui/webmcp-provider.spec.tsx src/mdx/components/shuffle-letters-demo/shuffle-letters-demo.spec.tsx
+```
+
+Expected: PASS.
+
+- [ ] **Step 2: Run affected existing tests**
+
+Run:
+
+```bash
+pnpm test:unit src/components/sound/ui/sound-switcher.spec.tsx src/components/series/test/series-navigation-top.spec.tsx src/components/series/test/series-navigation-bottom.spec.tsx src/mdx/mdx.spec.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 3: Run full static verification**
+
+Run:
+
+```bash
+pnpm check-types
+pnpm lint
+```
+
+Expected: PASS.
+
+- [ ] **Step 4: Run production build**
+
+Run:
+
+```bash
+pnpm build
+```
+
+Expected: PASS. The build must not report route errors for `/api/webmcp/content-index`.
+
+- [ ] **Step 5: Manual WebMCP QA in Chrome**
+
+Use Chrome with `chrome://flags/#enable-webmcp-testing` enabled and the Model Context Tool Inspector Extension installed.
+
+Check these routes:
+
+```text
+/
+/article
+/article/<known-article-slug>
+/craft
+/craft/<known-craft-slug>
+/playground/shuffle-letters
+```
+
+Expected:
+
+- `/` registers global tools only.
+- `/article` and `/craft` register global tools plus content search/open tools.
+- article/craft detail pages register current content context and heading tools.
+- pages with code blocks register `copy_code_block`.
+- pages with series navigation register `open_series`.
+- `/playground/shuffle-letters` registers `run_shuffle_letters` and `stop_shuffle_letters`.
+- Unsupported browsers have no console errors and no visible UI changes.
+
+- [ ] **Step 6: Review final history**
+
+Run:
+
+```bash
+git log --oneline -8
+git status --short
+```
+
+Expected:
+
+- The latest commits are the focused WebMCP commits from this plan.
+- `git status --short` contains only user-owned pre-existing untracked files, such as `github-profile-README.md`, or is clean.

--- a/docs/superpowers/specs/2026-05-28-webmcp-design.md
+++ b/docs/superpowers/specs/2026-05-28-webmcp-design.md
@@ -1,0 +1,407 @@
+# WebMCP 적극 적용 설계
+
+## 배경
+
+WebMCP는 브라우저가 열린 상태에서 웹 페이지가 AI 에이전트에게 구조화된
+도구를 노출하도록 제안된 표준이다. bendd.me는 블로그, craft, MDX 문서,
+플레이그라운드, 전역 설정처럼 사람이 조작하는 표면이 명확하므로 WebMCP를
+progressive enhancement로 적용하기 좋다.
+
+이 설계는 프로덕션 번들에 WebMCP 지원을 포함하되, 브라우저가
+`navigator.modelContext`를 제공할 때만 활성화한다. 지원하지 않는 브라우저는
+기존 동작과 성능이 변하지 않아야 한다.
+
+## 목표
+
+- 전역 내비게이션, 콘텐츠 탐색, 현재 문서 컨텍스트, MDX 액션, 플레이그라운드
+  실행을 WebMCP 도구로 적극 노출한다.
+- 안전한 동작은 에이전트가 자동 실행할 수 있게 한다.
+- 외부 링크 이동, 이메일 작성, 사용자의 브라우저 밖 부작용은 자동 실행하지
+  않는다.
+- 현재 글의 전체 본문은 반환하지 않고, 제목, 날짜, TL;DR, 설명, 목차, 짧은
+  excerpt까지만 반환한다.
+- WebMCP 미지원 브라우저의 런타임 비용은 사실상 0에 가깝게 유지한다.
+- 지원 브라우저에서도 초기 렌더링, MDX 렌더링, 스크롤 성능에 영향을 주지
+  않는다.
+
+## 비목표
+
+- headless agent가 브라우저 컨텍스트 없이 호출할 수 있는 별도 서버 MCP를 만들지
+  않는다.
+- 전체 MDX 원문을 도구 출력으로 제공하지 않는다.
+- GitHub, YouTube, Chrome Web Store, `mailto:` 같은 외부 링크를 도구 호출만으로
+  자동으로 열지 않는다.
+- WebMCP 전용 디버그 패널을 사이트 안에 만들지 않는다. 검증은 Chrome flag와
+  Model Context Tool Inspector Extension을 사용한다.
+
+## 적용 방식
+
+하이브리드 적극 적용을 사용한다.
+
+- Imperative API: 사이트 전역, 콘텐츠 탐색, 현재 문서 컨텍스트, 상태 토글,
+  MDX 액션을 등록한다.
+- Declarative API: 실제 폼이 존재하는 `ShuffleLettersDemo` 계열에
+  `toolname`, `tooldescription`, `toolparamdescription`, `toolautosubmit`을
+  추가한다.
+- 두 API 모두 progressive enhancement로 동작한다. WebMCP API가 없으면 등록,
+  DOM 스캔, schema 생성을 수행하지 않는다.
+
+## 컴포넌트 구조
+
+새 도메인 컴포넌트는 `src/components/webmcp/` 아래에 둔다.
+
+```text
+src/components/webmcp/
+├── index.ts
+├── ui/webmcp-provider.tsx
+├── model/use-webmcp-tools.ts
+├── lib/register-tool.ts
+├── lib/content-snapshot.ts
+├── lib/schemas.ts
+└── types/webmcp.d.ts
+```
+
+콘텐츠 검색용 인덱스는 별도 route handler로 제공한다.
+
+```text
+src/app/api/webmcp/content-index/route.ts
+```
+
+- `index.ts`: `WebMCPProvider`만 공개한다.
+- `ui/webmcp-provider.tsx`: root layout에서 client-only로 마운트되는 entry point다.
+- `model/use-webmcp-tools.ts`: 현재 route와 페이지 상태에 맞는 도구 목록을 만든다.
+- `lib/register-tool.ts`: `navigator.modelContext.registerTool` 호출과
+  `AbortController` cleanup을 감싼다.
+- `lib/content-snapshot.ts`: 현재 페이지에서 안전하게 노출할 콘텐츠 정보를
+  추출한다.
+- `lib/schemas.ts`: JSON Schema 객체를 도구별로 중앙화한다.
+- `types/webmcp.d.ts`: 실험 API 타입을 로컬로 선언한다.
+- `src/app/api/webmcp/content-index/route.ts`: `find_content`가 호출될 때만
+  fetch하는 작은 JSON 인덱스를 반환한다.
+
+## 등록 생명주기
+
+`WebMCPProvider`는 route change마다 다음 순서를 따른다.
+
+1. 브라우저 환경인지 확인한다.
+2. `navigator.modelContext`가 없으면 즉시 종료한다.
+3. `requestIdleCallback`이 있으면 idle 시점에, 없으면 `setTimeout(0)` 뒤에 등록을
+   시작한다.
+4. 현재 route에서 필요한 도구만 등록한다.
+5. route가 바뀌거나 provider가 unmount되면 `AbortController.abort()`로 이전 도구를
+   해제한다.
+
+중복 목적의 도구를 등록하지 않는다. 예를 들어 `open_content`는 내부 콘텐츠
+이동만 담당하고, `find_content`는 검색 결과 반환만 담당한다.
+
+## 도구 목록
+
+### 전역 도구
+
+#### `navigate_site`
+
+홈, article, craft, shuffle playground로 내부 이동한다.
+
+입력:
+
+- `destination`: `"home" | "article" | "craft" | "shuffle-playground"`
+
+출력:
+
+- 이동한 내부 경로 문자열
+
+#### `get_site_context`
+
+현재 경로, 문서 제목, canonical URL, 사용 가능한 주요 영역, 현재 route에서 등록된
+액션 요약을 반환한다.
+
+입력:
+
+- 없음
+
+출력:
+
+- 현재 페이지 컨텍스트 객체
+
+#### `toggle_theme`
+
+테마를 토글한다. 실제 UI 버튼과 같은 상태 변경 경로를 사용한다.
+
+입력:
+
+- 없음
+
+출력:
+
+- 변경 후 테마 상태
+
+#### `set_sound`
+
+사운드 설정을 켜거나 끈다. Zustand persist store와 동일한 상태를 갱신한다.
+
+입력:
+
+- `enabled`: boolean
+
+출력:
+
+- 변경 후 사운드 상태
+
+#### `copy_current_url`
+
+현재 URL을 클립보드에 복사한다.
+
+입력:
+
+- 없음
+
+출력:
+
+- 복사 성공 여부와 URL
+
+### 콘텐츠 도구
+
+#### `find_content`
+
+article과 craft 인덱스에서 제목, 요약, 설명, 카테고리, 날짜, 시리즈 정보를 기준으로
+콘텐츠를 찾는다.
+
+입력:
+
+- `query`: string
+- `type`: `"all" | "article" | "craft"` 기본값 `"all"`
+- `limit`: number, 1에서 10 사이
+
+출력:
+
+- `type`, `slug`, `title`, `summary`, `description`, `publishedAt`, `category`,
+  `series`, `href`로 구성된 결과 배열
+
+#### `open_content`
+
+내부 article 또는 craft 상세 페이지로 이동한다.
+
+입력:
+
+- `type`: `"article" | "craft"`
+- `slug`: string
+
+출력:
+
+- 이동한 내부 경로 문자열
+
+#### `get_current_content_context`
+
+현재 article 또는 craft 상세 페이지의 짧은 컨텍스트를 반환한다. 전체 본문 대신
+제목, 날짜, TL;DR, description, 목차, 첫 문단 기반 excerpt를 사용한다.
+
+입력:
+
+- 없음
+
+출력:
+
+- 현재 콘텐츠 컨텍스트 객체
+
+#### `open_series`
+
+현재 글의 시리즈 이동 또는 시리즈 목록 이동을 수행한다. 시리즈 정보가 없는 글에서는
+명확한 오류 문자열을 반환한다.
+
+입력:
+
+- `target`: `"series" | "previous" | "next"`
+
+출력:
+
+- 이동한 내부 경로 문자열 또는 사용 가능한 시리즈 이동 정보
+
+### 문서와 MDX 도구
+
+#### `jump_to_heading`
+
+현재 문서의 heading id로 스크롤한다.
+
+입력:
+
+- `headingId`: string
+
+출력:
+
+- 스크롤한 heading 제목과 id
+
+#### `copy_code_block`
+
+현재 글의 특정 코드 블록 텍스트를 클립보드에 복사한다.
+
+입력:
+
+- `index`: number, 0부터 시작
+
+출력:
+
+- 복사 성공 여부, 코드 블록 언어, 글자 수
+
+#### `list_page_actions`
+
+현재 페이지에서 의미 있게 실행할 수 있는 WebMCP 액션 요약을 반환한다. 이 도구는
+agent가 어떤 도구를 써야 할지 판단하기 위한 read-only 보조 도구다.
+
+입력:
+
+- 없음
+
+출력:
+
+- 현재 route에서 사용 가능한 액션 목록
+
+### 플레이그라운드 도구
+
+#### `run_shuffle_letters`
+
+shuffle letters 데모 폼을 채우고 애니메이션을 실행한다.
+
+입력:
+
+- `text`: string
+- `iterations`: number, 1에서 50 사이
+- `fps`: number, 1에서 60 사이
+
+출력:
+
+- 적용된 값과 실행 상태
+
+#### `stop_shuffle_letters`
+
+실행 중인 shuffle letters 애니메이션을 중단한다.
+
+입력:
+
+- 없음
+
+출력:
+
+- 중단 여부
+
+## 콘텐츠 인덱스
+
+콘텐츠 인덱스는 전체 MDX 본문을 포함하지 않는다.
+
+```ts
+type WebMCPContentIndexItem = {
+  type: 'article' | 'craft';
+  slug: string;
+  title: string;
+  summary: string;
+  description: string;
+  publishedAt: string;
+  category: string;
+  href: string;
+  series?: {
+    id: string;
+    name: string;
+    order?: number;
+  };
+};
+```
+
+인덱스는 서버에서 기존 `readArticles()`, `readCraftArticles()`,
+`formatArticlesForDisplay()` 계열 흐름을 재사용해 만든다. root layout이나 모든
+페이지에서 인덱스를 미리 만들지 않는다. `find_content`가 실제로 실행될 때
+`/api/webmcp/content-index`를 lazy fetch하고, 같은 브라우저 세션에서는 메모리에
+cache한다.
+
+## 현재 문서 스냅샷
+
+현재 페이지의 본문 일부는 도구 실행 시점에만 DOM에서 읽는다.
+
+- 제목: 가장 가까운 `h1` 또는 layout 제목
+- TL;DR: article layout의 blockquote 텍스트
+- 목차: `article` 내부 `h2`, `h4`의 id와 텍스트
+- excerpt: 첫 번째 의미 있는 문단에서 최대 300자
+- 코드 블록: `pre` 요소에 `data-webmcp-code-index`를 부여해 인덱스로 조회
+
+DOM 스캔은 article/craft 상세 route에서만 수행하고, route lifecycle 동안 memoize한다.
+
+## 성능 제약
+
+성능은 기능보다 우선한다.
+
+- WebMCP 미지원 브라우저에서는 feature detection 이후 즉시 반환한다.
+- feature detection 전에는 DOM 스캔, schema 생성을 수행하지 않는다.
+- 콘텐츠 인덱스는 페이지 로드 중 만들지 않고, `find_content` 실행 시에만 fetch한다.
+- provider는 client-only dynamic import로 분리해 기본 서버 렌더링 경로를
+  건드리지 않는다.
+- 첫 등록은 idle 시점으로 미룬다.
+- observer, interval, scroll listener를 추가하지 않는다.
+- heading과 code block 스캔은 상세 route에서만 한 번 수행한다.
+- 도구 실행 함수 안에서만 DOM 변경, 클립보드, 스크롤, 토글을 수행한다.
+- 콘텐츠 인덱스에는 전체 본문을 넣지 않는다.
+- 등록된 도구 수는 현재 route에 필요한 것으로 제한한다.
+
+## 보안과 권한
+
+- `Permissions-Policy`에는 WebMCP 도구가 같은 origin에서만 동작한다는 의도를
+  명시한다. WebMCP의 기본 정책은 self지만, `tools=(self)`를 추가해 설정을
+  문서화한다.
+- `next.config.mjs`의 기존 camera, microphone, geolocation 차단은 유지한다.
+- cross-origin iframe에 `allow="tools"`를 추가하지 않는다.
+- 외부 링크는 도구가 자동으로 열지 않는다.
+- 클립보드 작업이 실패하면 에러를 반환하고 UI를 변경하지 않는다.
+- 도구 입력은 JSON Schema와 handler 내부 검증을 함께 적용한다.
+
+## 오류 처리
+
+- WebMCP API가 없거나 예상 signature와 다르면 조용히 비활성화한다.
+- 잘못된 slug, heading id, code block index는 구조화된 오류 문자열을 반환한다.
+- `iterations`, `fps`, `limit`이 허용 범위를 벗어나면 실행하지 않고 재시도 가능한
+  오류를 반환한다.
+- 현재 route에서 사용할 수 없는 도구가 호출되면 가능한 액션 목록을 함께 반환한다.
+- 내부 이동은 Next router를 사용한다. 실패하면 목적 경로를 포함한 오류를 반환한다.
+
+## 테스트 전략
+
+Unit test:
+
+- `register-tool` helper가 mock `navigator.modelContext`에 도구를 등록하고
+  cleanup에서 abort하는지 검증한다.
+- 콘텐츠 인덱스 route가 article과 craft를 구분하고 전체 MDX 본문을 포함하지 않는지
+  검증한다.
+- `find_content`, `open_content`, `get_current_content_context`,
+  `run_shuffle_letters` handler를 mock DOM과 mock router로 검증한다.
+- 범위 밖 입력과 없는 slug, 없는 heading, 없는 code block index의 오류 메시지를
+  검증한다.
+
+Static verification:
+
+- `pnpm check-types`
+- `pnpm lint`
+- 필요한 경우 `pnpm test:unit`
+
+Manual QA:
+
+- Chrome에서 `chrome://flags/#enable-webmcp-testing` 활성화
+- Model Context Tool Inspector Extension으로 route별 도구 등록 확인
+- 홈, article 목록, article 상세, craft 목록, craft 상세, shuffle playground에서
+  사용 가능한 도구가 겹치지 않는지 확인
+- WebMCP 미지원 브라우저에서 콘솔 오류와 UI 변화가 없는지 확인
+
+## 구현 순서
+
+1. WebMCP 타입, schema, registration helper를 만든다.
+2. 콘텐츠 인덱스 route와 provider entry point를 만든다.
+3. root layout에 client-only provider를 연결한다.
+4. 전역 도구를 등록한다.
+5. 콘텐츠 검색과 내부 이동 도구를 등록한다.
+6. 현재 문서 컨텍스트, heading 이동, code copy 도구를 등록한다.
+7. ShuffleLettersDemo에 declarative 속성과 imperative handler를 연결한다.
+8. next config의 `Permissions-Policy`에 `tools=(self)`를 명시한다.
+9. unit test와 수동 QA 체크리스트를 추가한다.
+
+## 참고 자료
+
+- [WebMCP overview](https://developer.chrome.com/docs/ai/webmcp)
+- [WebMCP Imperative API](https://developer.chrome.com/docs/ai/webmcp/imperative-api)
+- [WebMCP Declarative API](https://developer.chrome.com/docs/ai/webmcp/declarative-api)
+- [WebMCP best practices](https://developer.chrome.com/docs/ai/webmcp/best-practices)
+- [WebMCP evals](https://developer.chrome.com/docs/ai/webmcp/evals)

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -70,7 +70,7 @@ const securityHeaders = [
   },
   {
     key: 'Permissions-Policy',
-    value: 'camera=(), microphone=(), geolocation=()',
+    value: 'camera=(), microphone=(), geolocation=(), tools=(self)',
   },
 ];
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,2 @@
+allowBuilds:
+  esbuild: true

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,2 +1,5 @@
+packages:
+  - .
+
 allowBuilds:
   esbuild: true

--- a/src/app/api/webmcp/content-index/route.spec.ts
+++ b/src/app/api/webmcp/content-index/route.spec.ts
@@ -1,0 +1,47 @@
+/* eslint-disable playwright/no-standalone-expect */
+import { describe, expect, it, vi } from 'vitest';
+
+import { GET } from '@/app/api/webmcp/content-index/route';
+import { createWebMCPContentIndex } from '@/components/webmcp/lib/content-index';
+
+vi.mock('@/components/webmcp/lib/content-index', () => ({
+  createWebMCPContentIndex: vi.fn(() => [
+    {
+      type: 'article',
+      slug: 'agentic-interfaces',
+      title: 'Agentic Interfaces',
+      summary: 'Interfaces for agents',
+      description: 'A practical note about interfaces for agent workflows.',
+      publishedAt: '2026-05-20',
+      category: 'AI',
+      href: '/article/agentic-interfaces',
+      series: { id: 'ai-interfaces', name: 'AI Interfaces', order: 2 },
+    },
+  ]),
+}));
+
+describe('GET /api/webmcp/content-index', () => {
+  it('returns the content index with cache headers', async () => {
+    const response = GET();
+
+    await expect(response.json()).resolves.toEqual({
+      items: [
+        {
+          type: 'article',
+          slug: 'agentic-interfaces',
+          title: 'Agentic Interfaces',
+          summary: 'Interfaces for agents',
+          description: 'A practical note about interfaces for agent workflows.',
+          publishedAt: '2026-05-20',
+          category: 'AI',
+          href: '/article/agentic-interfaces',
+          series: { id: 'ai-interfaces', name: 'AI Interfaces', order: 2 },
+        },
+      ],
+    });
+    expect(response.headers.get('Cache-Control')).toBe(
+      'public, max-age=300, s-maxage=3600'
+    );
+    expect(createWebMCPContentIndex).toHaveBeenCalledOnce();
+  });
+});

--- a/src/app/api/webmcp/content-index/route.ts
+++ b/src/app/api/webmcp/content-index/route.ts
@@ -1,0 +1,12 @@
+import { createWebMCPContentIndex } from '@/components/webmcp/lib/content-index';
+
+export function GET() {
+  return Response.json(
+    { items: createWebMCPContentIndex() },
+    {
+      headers: {
+        'Cache-Control': 'public, max-age=300, s-maxage=3600',
+      },
+    }
+  );
+}

--- a/src/app/api/webmcp/content-index/route.ts
+++ b/src/app/api/webmcp/content-index/route.ts
@@ -1,5 +1,7 @@
 import { createWebMCPContentIndex } from '@/components/webmcp/lib/content-index';
 
+export const dynamic = 'force-static';
+
 export function GET() {
   return Response.json(
     { items: createWebMCPContentIndex() },

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -30,6 +30,13 @@ const BrowserDetector = dynamic(
   }
 );
 
+const WebMCPProvider = dynamic(
+  () => import('@/components/webmcp').then(mod => mod.WebMCPProvider),
+  {
+    ssr: false,
+  }
+);
+
 const fontSans = FontSans({
   subsets: ['latin'],
   display: 'swap',
@@ -130,6 +137,7 @@ export default function RootLayout({
           enableSystem
           disableTransitionOnChange
         >
+          <WebMCPProvider />
           <TooltipProvider>
             <Signature />
             {children}

--- a/src/app/playground/shuffle-letters/page.tsx
+++ b/src/app/playground/shuffle-letters/page.tsx
@@ -4,6 +4,17 @@ import { shuffleLetters } from '@/components/article/lib/shuffle-letters';
 import { Button } from '@/components/ui/button';
 import { useCallback, useEffect, useRef, useState } from 'react';
 
+type ShuffleLettersPayload = {
+  text: string;
+  iterations: number;
+  fps: number;
+};
+
+type AgentSubmitEvent = SubmitEvent & {
+  agentInvoked?: boolean;
+  respondWith?: (promise: Promise<unknown>) => void;
+};
+
 export default function ShuffleLettersDemo() {
   const [text, setText] = useState(
     '한글 English 123456789 @#$%^&*()_+-=[]{}|;:,.<>?'
@@ -29,19 +40,48 @@ export default function ShuffleLettersDemo() {
     }
   }, [text]);
 
+  const startAnimation = useCallback(
+    ({
+      text: nextText,
+      iterations: nextIterations,
+      fps: nextFps,
+    }: ShuffleLettersPayload) => {
+      if (isAnimating || !animatedTextRef.current) return false;
+
+      setText(nextText);
+      setIterations(nextIterations);
+      setFps(nextFps);
+      animatedTextRef.current.textContent = nextText;
+      setIsAnimating(true);
+      clearAnimationRef.current = shuffleLetters(animatedTextRef.current, {
+        iterations: nextIterations,
+        fps: nextFps,
+        onComplete: () => {
+          setIsAnimating(false);
+          clearAnimationRef.current = null;
+        },
+      });
+
+      return true;
+    },
+    [isAnimating]
+  );
+
   const handleSubmit = (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
-    if (isAnimating) return;
+    const started = startAnimation({ text, iterations, fps });
+    const nativeEvent = e.nativeEvent as AgentSubmitEvent;
 
-    setIsAnimating(true);
-    clearAnimationRef.current = shuffleLetters(animatedTextRef.current!, {
-      iterations,
-      fps,
-      onComplete: () => {
-        setIsAnimating(false);
-        clearAnimationRef.current = null;
-      },
-    });
+    if (nativeEvent.agentInvoked && nativeEvent.respondWith) {
+      nativeEvent.respondWith(
+        Promise.resolve({
+          ok: started,
+          text,
+          iterations,
+          fps,
+        })
+      );
+    }
   };
 
   useEffect(() => {
@@ -54,6 +94,26 @@ export default function ShuffleLettersDemo() {
     window.addEventListener('keydown', handleKeyDown);
     return () => window.removeEventListener('keydown', handleKeyDown);
   }, [isAnimating, stopAnimation]);
+
+  useEffect(() => {
+    const handleRun = (event: Event) => {
+      const { detail } = event as CustomEvent<ShuffleLettersPayload>;
+      if (!detail) return;
+      startAnimation(detail);
+    };
+
+    const handleStop = () => {
+      stopAnimation();
+    };
+
+    window.addEventListener('webmcp:run-shuffle-letters', handleRun);
+    window.addEventListener('webmcp:stop-shuffle-letters', handleStop);
+
+    return () => {
+      window.removeEventListener('webmcp:run-shuffle-letters', handleRun);
+      window.removeEventListener('webmcp:stop-shuffle-letters', handleStop);
+    };
+  }, [startAnimation, stopAnimation]);
 
   const isValid =
     text.trim() !== '' &&
@@ -71,23 +131,26 @@ export default function ShuffleLettersDemo() {
       </p>
 
       <form
+        aria-label="Shuffle letters playground"
+        toolname="run_shuffle_letters"
+        tooldescription="Runs the shuffle letters animation with visible form values."
+        toolautosubmit=""
         onSubmit={handleSubmit}
         className="w-full max-w-md rounded-lg p-6 shadow-md"
       >
         <h2 className="mb-4 text-xl font-semibold">옵션</h2>
 
         <div className="mb-4">
-          <label
-            htmlFor="text"
-            className="mb-2 block text-sm font-medium"
-          >
+          <label htmlFor="text" className="mb-2 block text-sm font-medium">
             text
           </label>
           <input
             id="text"
+            name="text"
             type="text"
             value={text}
             onChange={e => setText(e.target.value)}
+            toolparamdescription="Text to animate with the shuffle letters effect."
             className="w-full rounded-md border border-input px-3 py-2"
             required
           />
@@ -103,29 +166,30 @@ export default function ShuffleLettersDemo() {
             </label>
             <input
               id="iterations"
+              name="iterations"
               type="number"
               value={iterations}
               onChange={e => setIterations(Number(e.target.value))}
               min="1"
               max="50"
+              toolparamdescription="Number of random character replacements per letter. Use 1 through 50."
               className="w-full rounded-md border border-input px-3 py-2"
               required
             />
           </div>
           <div className="flex-1">
-            <label
-              htmlFor="fps"
-              className="mb-2 block text-sm font-medium"
-            >
+            <label htmlFor="fps" className="mb-2 block text-sm font-medium">
               fps
             </label>
             <input
               id="fps"
+              name="fps"
               type="number"
               value={fps}
               onChange={e => setFps(Number(e.target.value))}
               min="1"
               max="60"
+              toolparamdescription="Animation frames per second. Use 1 through 60."
               className="w-full rounded-md border border-input px-3 py-2"
               required
             />

--- a/src/app/playground/shuffle-letters/page.tsx
+++ b/src/app/playground/shuffle-letters/page.tsx
@@ -15,6 +15,11 @@ type AgentSubmitEvent = SubmitEvent & {
   respondWith?: (promise: Promise<unknown>) => void;
 };
 
+const invalidPayloadResponse = {
+  ok: false,
+  error: 'text, iterations, fps 값이 올바르지 않습니다.',
+} as const;
+
 function parseShuffleLettersPayload(
   detail: unknown
 ): ShuffleLettersPayload | null {
@@ -101,17 +106,22 @@ export default function ShuffleLettersDemo() {
 
   const handleSubmit = (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
-    const started = startAnimation({ text, iterations, fps });
+    const payload = parseShuffleLettersPayload({ text, iterations, fps });
+    const started = payload ? startAnimation(payload) : false;
     const nativeEvent = e.nativeEvent as AgentSubmitEvent;
 
     if (nativeEvent.agentInvoked && nativeEvent.respondWith) {
       nativeEvent.respondWith(
-        Promise.resolve({
-          ok: started,
-          text,
-          iterations,
-          fps,
-        })
+        Promise.resolve(
+          payload
+            ? {
+                ok: started,
+                text: payload.text,
+                iterations: payload.iterations,
+                fps: payload.fps,
+              }
+            : invalidPayloadResponse
+        )
       );
     }
   };

--- a/src/app/playground/shuffle-letters/page.tsx
+++ b/src/app/playground/shuffle-letters/page.tsx
@@ -15,6 +15,38 @@ type AgentSubmitEvent = SubmitEvent & {
   respondWith?: (promise: Promise<unknown>) => void;
 };
 
+function parseShuffleLettersPayload(
+  detail: unknown
+): ShuffleLettersPayload | null {
+  if (typeof detail !== 'object' || detail === null) return null;
+
+  const { text, iterations, fps } = detail as Partial<
+    Record<keyof ShuffleLettersPayload, unknown>
+  >;
+
+  if (typeof text !== 'string' || text.trim() === '') return null;
+  if (
+    typeof iterations !== 'number' ||
+    !Number.isFinite(iterations) ||
+    !Number.isInteger(iterations) ||
+    iterations < 1 ||
+    iterations > 50
+  ) {
+    return null;
+  }
+  if (
+    typeof fps !== 'number' ||
+    !Number.isFinite(fps) ||
+    !Number.isInteger(fps) ||
+    fps < 1 ||
+    fps > 60
+  ) {
+    return null;
+  }
+
+  return { text, iterations, fps };
+}
+
 export default function ShuffleLettersDemo() {
   const [text, setText] = useState(
     '한글 English 123456789 @#$%^&*()_+-=[]{}|;:,.<>?'
@@ -24,21 +56,20 @@ export default function ShuffleLettersDemo() {
   const [isAnimating, setIsAnimating] = useState(false);
   const animatedTextRef = useRef<HTMLDivElement>(null);
   const clearAnimationRef = useRef<(() => void) | null>(null);
+  const intendedDisplayTextRef = useRef(text);
 
   const stopAnimation = useCallback(() => {
     if (clearAnimationRef.current) {
       clearAnimationRef.current();
-      (
-        clearAnimationRef as React.MutableRefObject<(() => void) | null>
-      ).current = null;
+      clearAnimationRef.current = null;
       setIsAnimating(false);
 
       // 즉시 텍스트를 원래 상태로 되돌립니다.
       if (animatedTextRef.current) {
-        animatedTextRef.current.textContent = text;
+        animatedTextRef.current.textContent = intendedDisplayTextRef.current;
       }
     }
-  }, [text]);
+  }, []);
 
   const startAnimation = useCallback(
     ({
@@ -46,8 +77,9 @@ export default function ShuffleLettersDemo() {
       iterations: nextIterations,
       fps: nextFps,
     }: ShuffleLettersPayload) => {
-      if (isAnimating || !animatedTextRef.current) return false;
+      if (clearAnimationRef.current || !animatedTextRef.current) return false;
 
+      intendedDisplayTextRef.current = nextText;
       setText(nextText);
       setIterations(nextIterations);
       setFps(nextFps);
@@ -64,7 +96,7 @@ export default function ShuffleLettersDemo() {
 
       return true;
     },
-    [isAnimating]
+    []
   );
 
   const handleSubmit = (e: React.FormEvent<HTMLFormElement>) => {
@@ -97,9 +129,10 @@ export default function ShuffleLettersDemo() {
 
   useEffect(() => {
     const handleRun = (event: Event) => {
-      const { detail } = event as CustomEvent<ShuffleLettersPayload>;
-      if (!detail) return;
-      startAnimation(detail);
+      const { detail } = event as CustomEvent<unknown>;
+      const payload = parseShuffleLettersPayload(detail);
+      if (!payload) return;
+      startAnimation(payload);
     };
 
     const handleStop = () => {

--- a/src/components/layout/mdx.tsx
+++ b/src/components/layout/mdx.tsx
@@ -82,7 +82,18 @@ export function MdxLayout({ post, type, seriesInfo }: MdxLayoutProps) {
 
   return (
     <main className="relative mx-auto my-0 min-h-screen max-w-2xl overflow-hidden px-6 py-32">
-      <section id="BenddDoc">
+      <section
+        id="BenddDoc"
+        data-webmcp-content
+        data-webmcp-content-type={type}
+        data-webmcp-slug={post.slug}
+        data-webmcp-title={title}
+        data-webmcp-published-at={publishedAt}
+        data-webmcp-description={description}
+        data-webmcp-summary={summary}
+        data-webmcp-series-id={seriesInfo?.id}
+        data-webmcp-series-name={seriesInfo?.name}
+      >
         <script
           type="application/ld+json"
           suppressHydrationWarning
@@ -124,11 +135,7 @@ export function MdxLayout({ post, type, seriesInfo }: MdxLayoutProps) {
             })}
           </p>
         </Typography>
-        <Typography
-          variant="blockquote"
-          className="mt-6 break-keep"
-          asChild
-        >
+        <Typography variant="blockquote" className="mt-6 break-keep" asChild>
           <blockquote>
             <p>
               <strong>TL;DR</strong>: {description}

--- a/src/components/series/ui/series-navigation-bottom.tsx
+++ b/src/components/series/ui/series-navigation-bottom.tsx
@@ -26,6 +26,7 @@ export function SeriesNavigationBottom({
     >
       <Link
         href={seriesRoute(id)}
+        data-webmcp-series-target="series"
         className="mb-4 flex items-center gap-2 text-sm font-medium transition-colors hover:text-primary"
       >
         <BookOpen className="size-4 shrink-0" />
@@ -39,6 +40,7 @@ export function SeriesNavigationBottom({
           {prev ? (
             <Link
               href={prev.href}
+              data-webmcp-series-target="previous"
               className="group flex flex-1 flex-col gap-1 rounded-md p-2 text-sm transition-colors hover:bg-muted"
             >
               <span className="flex items-center gap-1 text-xs text-muted-foreground">
@@ -55,6 +57,7 @@ export function SeriesNavigationBottom({
           {next ? (
             <Link
               href={next.href}
+              data-webmcp-series-target="next"
               className="group flex flex-1 flex-col items-end gap-1 rounded-md p-2 text-sm transition-colors hover:bg-muted"
             >
               <span className="flex items-center gap-1 text-xs text-muted-foreground">

--- a/src/components/series/ui/series-navigation-top.tsx
+++ b/src/components/series/ui/series-navigation-top.tsx
@@ -19,6 +19,7 @@ export function SeriesNavigationTop({
     >
       <Link
         href={seriesRoute(id)}
+        data-webmcp-series-target="series"
         className="mb-4 flex items-center gap-2 text-sm font-medium transition-colors hover:text-primary"
       >
         <BookOpen className="size-4 shrink-0" />

--- a/src/components/sound/model/sound-store.ts
+++ b/src/components/sound/model/sound-store.ts
@@ -4,6 +4,7 @@ import { persist } from 'zustand/middleware';
 type SoundState = {
   isSoundEnabled: boolean;
   toggleSoundEnabled: () => void;
+  setSoundEnabled: (enabled: boolean) => void;
 };
 
 export const useSoundStore = create<SoundState>()(
@@ -12,6 +13,9 @@ export const useSoundStore = create<SoundState>()(
       isSoundEnabled: false,
       toggleSoundEnabled: () => {
         set({ isSoundEnabled: !get().isSoundEnabled });
+      },
+      setSoundEnabled: enabled => {
+        set({ isSoundEnabled: enabled });
       },
     }),
     {

--- a/src/components/ui/test/typography.spec.tsx
+++ b/src/components/ui/test/typography.spec.tsx
@@ -44,7 +44,7 @@ describe('typography component', () => {
     );
     const heading = screen.getByRole('heading');
     expect(heading.className).toContain(
-      'scroll-m-20 text-4xl font-extrabold tracking-tight md:text-5xl text-primary text-center text-secondary'
+      'scroll-m-20 text-4xl font-extrabold tracking-tight md:text-5xl text-center text-secondary'
     );
   });
   it('should forward a ref to the DOM element', () => {

--- a/src/components/webmcp/index.ts
+++ b/src/components/webmcp/index.ts
@@ -1,0 +1,1 @@
+export { WebMCPProvider } from '@/components/webmcp/ui/webmcp-provider';

--- a/src/components/webmcp/lib/content-index.spec.ts
+++ b/src/components/webmcp/lib/content-index.spec.ts
@@ -1,0 +1,99 @@
+/* eslint-disable playwright/no-standalone-expect */
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { createWebMCPContentIndex } from '@/components/webmcp/lib/content-index';
+import {
+  getSeriesBadges,
+  readArticles,
+  readCraftArticles,
+  sortByDateDesc,
+  type Article,
+} from '@/mdx/mdx';
+
+vi.mock('@/mdx/mdx', () => ({
+  getSeriesBadges: vi.fn(),
+  readArticles: vi.fn(),
+  readCraftArticles: vi.fn(),
+  sortByDateDesc: vi.fn((articles: ReadonlyArray<Article>) => articles),
+}));
+
+const article: Article = {
+  slug: 'agentic-interfaces',
+  content: 'FULL ARTICLE BODY MUST NOT LEAK',
+  metadata: {
+    title: 'Agentic Interfaces',
+    summary: 'Interfaces for agents',
+    description: 'A practical note about interfaces for agent workflows.',
+    publishedAt: '2026-05-20',
+    category: 'AI',
+    series: 'ai-interfaces',
+    seriesOrder: 2,
+  },
+};
+
+const craft: Article = {
+  slug: 'interaction-sketch',
+  content: 'FULL CRAFT BODY MUST NOT LEAK',
+  metadata: {
+    title: 'Interaction Sketch',
+    summary: 'A small craft piece',
+    description: 'A craft note about interaction details.',
+    publishedAt: '2026-05-21',
+    category: 'Craft',
+  },
+};
+
+describe('createWebMCPContentIndex', () => {
+  beforeEach(() => {
+    vi.mocked(readArticles).mockReturnValue([article]);
+    vi.mocked(readCraftArticles).mockReturnValue([craft]);
+    vi.mocked(sortByDateDesc).mockImplementation(
+      (articles: ReadonlyArray<Article>) => articles
+    );
+    vi.mocked(getSeriesBadges).mockReturnValue(
+      new Map([
+        [
+          'agentic-interfaces',
+          { id: 'ai-interfaces', name: 'AI Interfaces', order: 2, total: 3 },
+        ],
+      ])
+    );
+  });
+
+  it('returns article and craft metadata without leaking MDX content bodies', () => {
+    const items = createWebMCPContentIndex();
+
+    expect(items).toEqual([
+      {
+        type: 'article',
+        slug: 'agentic-interfaces',
+        title: 'Agentic Interfaces',
+        summary: 'Interfaces for agents',
+        description: 'A practical note about interfaces for agent workflows.',
+        publishedAt: '2026-05-20',
+        category: 'AI',
+        href: '/article/agentic-interfaces',
+        series: { id: 'ai-interfaces', name: 'AI Interfaces', order: 2 },
+      },
+      {
+        type: 'craft',
+        slug: 'interaction-sketch',
+        title: 'Interaction Sketch',
+        summary: 'A small craft piece',
+        description: 'A craft note about interaction details.',
+        publishedAt: '2026-05-21',
+        category: 'Craft',
+        href: '/craft/interaction-sketch',
+      },
+    ]);
+    expect(JSON.stringify(items)).not.toContain(
+      'FULL ARTICLE BODY MUST NOT LEAK'
+    );
+    expect(JSON.stringify(items)).not.toContain(
+      'FULL CRAFT BODY MUST NOT LEAK'
+    );
+    expect(sortByDateDesc).toHaveBeenCalledWith([article]);
+    expect(sortByDateDesc).toHaveBeenCalledWith([craft]);
+    expect(getSeriesBadges).toHaveBeenCalledWith([article]);
+  });
+});

--- a/src/components/webmcp/lib/content-index.ts
+++ b/src/components/webmcp/lib/content-index.ts
@@ -1,0 +1,57 @@
+import {
+  getSeriesBadges,
+  readArticles,
+  readCraftArticles,
+  sortByDateDesc,
+  type Article,
+} from '@/mdx/mdx';
+
+export type WebMCPContentIndexItem = {
+  type: 'article' | 'craft';
+  slug: string;
+  title: string;
+  summary: string;
+  description: string;
+  publishedAt: string;
+  category: string;
+  href: string;
+  series?: { id: string; name: string; order: number };
+};
+
+const toBaseIndexItem = (
+  article: Article,
+  type: WebMCPContentIndexItem['type']
+): Omit<WebMCPContentIndexItem, 'series'> => ({
+  type,
+  slug: article.slug,
+  title: article.metadata.title,
+  summary: article.metadata.summary,
+  description: article.metadata.description,
+  publishedAt: article.metadata.publishedAt,
+  category: article.metadata.category,
+  href: `/${type}/${article.slug}`,
+});
+
+export function createWebMCPContentIndex(): WebMCPContentIndexItem[] {
+  const articles = sortByDateDesc(readArticles());
+  const crafts = sortByDateDesc(readCraftArticles());
+  const seriesBadges = getSeriesBadges(articles);
+
+  return [
+    ...articles.map(article => {
+      const item: WebMCPContentIndexItem = toBaseIndexItem(article, 'article');
+      const series = seriesBadges.get(article.slug);
+
+      if (series) {
+        item.series = {
+          id: series.id,
+          name: series.name,
+          order: series.order,
+        };
+      }
+
+      return item;
+    }),
+    ...crafts.map(craft => toBaseIndexItem(craft, 'craft')),
+  ];
+}

--- a/src/components/webmcp/lib/content-snapshot.spec.ts
+++ b/src/components/webmcp/lib/content-snapshot.spec.ts
@@ -140,4 +140,22 @@ describe('content-snapshot', () => {
       'open_series',
     ]);
   });
+
+  it('lists shuffle actions only on the exact shuffle playground route', () => {
+    expect(getPageActions('/playground/shuffle-letters', document)).toContain(
+      'run_shuffle_letters'
+    );
+    expect(getPageActions('/playground/shuffle-letters', document)).toContain(
+      'stop_shuffle_letters'
+    );
+    expect(getPageActions('/playground/shuffle-letters/', document)).toContain(
+      'run_shuffle_letters'
+    );
+    expect(
+      getPageActions('/playground/shuffle-letters-preview', document)
+    ).not.toContain('run_shuffle_letters');
+    expect(
+      getPageActions('/playground/shuffle-letters-preview', document)
+    ).not.toContain('stop_shuffle_letters');
+  });
 });

--- a/src/components/webmcp/lib/content-snapshot.spec.ts
+++ b/src/components/webmcp/lib/content-snapshot.spec.ts
@@ -72,6 +72,24 @@ describe('content-snapshot', () => {
     });
   });
 
+  it('returns a structured failure when required content metadata is invalid', () => {
+    document.body.innerHTML = `
+      <section
+        data-webmcp-content
+        data-webmcp-content-type="page"
+        data-webmcp-slug=""
+        data-webmcp-title=""
+      >
+        <article><p>Invalid metadata.</p></article>
+      </section>
+    `;
+
+    expect(getCurrentContentContext(document)).toEqual({
+      ok: false,
+      error: 'WebMCP 콘텐츠 메타데이터가 올바르지 않습니다.',
+    });
+  });
+
   it('reads code block text by zero-based index', () => {
     expect(getCodeBlockText(0, document)).toEqual({
       ok: true,
@@ -136,6 +154,18 @@ describe('content-snapshot', () => {
     expect(getSeriesTargetHref('next', document)).toEqual({
       ok: false,
       error: 'next 시리즈 이동 링크를 찾지 못했습니다.',
+    });
+  });
+
+  it('rejects marked series links without hrefs', () => {
+    document.body.insertAdjacentHTML(
+      'beforeend',
+      '<a data-webmcp-series-target="next">Next</a>'
+    );
+
+    expect(getSeriesTargetHref('next', document)).toEqual({
+      ok: false,
+      error: 'next 시리즈 이동 링크에 href가 없습니다.',
     });
   });
 

--- a/src/components/webmcp/lib/content-snapshot.spec.ts
+++ b/src/components/webmcp/lib/content-snapshot.spec.ts
@@ -98,6 +98,21 @@ describe('content-snapshot', () => {
     });
   });
 
+  it('rejects headings outside the marked content article', () => {
+    document.body.insertAdjacentHTML(
+      'beforeend',
+      '<h2 id="outside">Outside heading</h2>'
+    );
+    const outsideHeading = document.getElementById('outside') as HTMLElement;
+    outsideHeading.scrollIntoView = vi.fn();
+
+    expect(jumpToHeading('outside', document)).toEqual({
+      ok: false,
+      error: 'outside heading을 찾지 못했습니다.',
+    });
+    expect(outsideHeading.scrollIntoView).not.toHaveBeenCalled();
+  });
+
   it('finds series target hrefs from marked links', () => {
     expect(getSeriesTargetHref('series', document)).toEqual({
       ok: true,

--- a/src/components/webmcp/lib/content-snapshot.spec.ts
+++ b/src/components/webmcp/lib/content-snapshot.spec.ts
@@ -30,6 +30,7 @@ describe('content-snapshot', () => {
           <article>
             <p>First paragraph that becomes a short excerpt for agent context.</p>
             <h2 id="overview">Overview</h2>
+            <h3 id="usage">Usage</h3>
             <h4 id="details">Details</h4>
             <pre data-webmcp-code-block><code>const value = 1;</code></pre>
           </article>
@@ -56,6 +57,7 @@ describe('content-snapshot', () => {
         'First paragraph that becomes a short excerpt for agent context.',
       headings: [
         { id: 'overview', title: 'Overview', level: 2 },
+        { id: 'usage', title: 'Usage', level: 3 },
         { id: 'details', title: 'Details', level: 4 },
       ],
     });
@@ -93,6 +95,19 @@ describe('content-snapshot', () => {
       title: 'Overview',
     });
     expect(heading.scrollIntoView).toHaveBeenCalledWith({
+      behavior: 'smooth',
+      block: 'start',
+    });
+
+    const h3 = document.getElementById('usage') as HTMLElement;
+    h3.scrollIntoView = vi.fn();
+
+    expect(jumpToHeading('usage', document)).toEqual({
+      ok: true,
+      headingId: 'usage',
+      title: 'Usage',
+    });
+    expect(h3.scrollIntoView).toHaveBeenCalledWith({
       behavior: 'smooth',
       block: 'start',
     });

--- a/src/components/webmcp/lib/content-snapshot.spec.ts
+++ b/src/components/webmcp/lib/content-snapshot.spec.ts
@@ -1,0 +1,128 @@
+/* eslint-disable playwright/no-standalone-expect */
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import {
+  getCodeBlockText,
+  getCurrentContentContext,
+  getPageActions,
+  getSeriesTargetHref,
+  jumpToHeading,
+} from '@/components/webmcp/lib/content-snapshot';
+
+describe('content-snapshot', () => {
+  beforeEach(() => {
+    document.body.innerHTML = `
+      <main>
+        <section
+          data-webmcp-content
+          data-webmcp-content-type="article"
+          data-webmcp-slug="agentic-interfaces"
+          data-webmcp-title="Agentic interfaces"
+          data-webmcp-published-at="2026-05-10"
+          data-webmcp-description="How agents use visible interfaces."
+          data-webmcp-summary="Agent UI notes"
+          data-webmcp-series-id="ai-agents"
+          data-webmcp-series-name="AI Agents"
+        >
+          <blockquote><p><strong>TL;DR</strong>: Visible tools help agents.</p></blockquote>
+          <a href="/article/series/ai-agents" data-webmcp-series-target="series">Series</a>
+          <a href="/article/previous" data-webmcp-series-target="previous">Previous</a>
+          <article>
+            <p>First paragraph that becomes a short excerpt for agent context.</p>
+            <h2 id="overview">Overview</h2>
+            <h4 id="details">Details</h4>
+            <pre data-webmcp-code-block><code>const value = 1;</code></pre>
+          </article>
+        </section>
+      </main>
+    `;
+  });
+
+  it('extracts current content context without full body text', () => {
+    expect(getCurrentContentContext(document)).toEqual({
+      ok: true,
+      type: 'article',
+      slug: 'agentic-interfaces',
+      title: 'Agentic interfaces',
+      publishedAt: '2026-05-10',
+      description: 'How agents use visible interfaces.',
+      summary: 'Agent UI notes',
+      series: {
+        id: 'ai-agents',
+        name: 'AI Agents',
+      },
+      tldr: 'TL;DR: Visible tools help agents.',
+      excerpt:
+        'First paragraph that becomes a short excerpt for agent context.',
+      headings: [
+        { id: 'overview', title: 'Overview', level: 2 },
+        { id: 'details', title: 'Details', level: 4 },
+      ],
+    });
+  });
+
+  it('returns a structured miss when no content marker exists', () => {
+    document.body.innerHTML = '<main><p>Home page</p></main>';
+
+    expect(getCurrentContentContext(document)).toEqual({
+      ok: false,
+      error: '현재 페이지에는 WebMCP 콘텐츠 컨텍스트가 없습니다.',
+    });
+  });
+
+  it('reads code block text by zero-based index', () => {
+    expect(getCodeBlockText(0, document)).toEqual({
+      ok: true,
+      language: '',
+      text: 'const value = 1;',
+      characterCount: 16,
+    });
+    expect(getCodeBlockText(1, document)).toEqual({
+      ok: false,
+      error: '1번 코드 블록을 찾지 못했습니다.',
+    });
+  });
+
+  it('scrolls to a heading by id', () => {
+    const heading = document.getElementById('overview') as HTMLElement;
+    heading.scrollIntoView = vi.fn();
+
+    expect(jumpToHeading('overview', document)).toEqual({
+      ok: true,
+      headingId: 'overview',
+      title: 'Overview',
+    });
+    expect(heading.scrollIntoView).toHaveBeenCalledWith({
+      behavior: 'smooth',
+      block: 'start',
+    });
+  });
+
+  it('finds series target hrefs from marked links', () => {
+    expect(getSeriesTargetHref('series', document)).toEqual({
+      ok: true,
+      href: '/article/series/ai-agents',
+    });
+    expect(getSeriesTargetHref('next', document)).toEqual({
+      ok: false,
+      error: 'next 시리즈 이동 링크를 찾지 못했습니다.',
+    });
+  });
+
+  it('lists route-relevant page actions', () => {
+    expect(getPageActions('/article/agentic-interfaces', document)).toEqual([
+      'navigate_site',
+      'get_site_context',
+      'toggle_theme',
+      'set_sound',
+      'copy_current_url',
+      'find_content',
+      'open_content',
+      'list_page_actions',
+      'get_current_content_context',
+      'jump_to_heading',
+      'copy_code_block',
+      'open_series',
+    ]);
+  });
+});

--- a/src/components/webmcp/lib/content-snapshot.ts
+++ b/src/components/webmcp/lib/content-snapshot.ts
@@ -120,7 +120,11 @@ export function getCodeBlockText(index: number, docLike?: Document) {
 
 export function jumpToHeading(headingId: string, docLike?: Document) {
   const doc = getDocument(docLike);
-  const heading = doc.getElementById(headingId);
+  const root = getContentRoot(doc);
+  const heading = [
+    ...(root?.querySelectorAll<HTMLElement>('article h2[id], article h4[id]') ??
+      []),
+  ].find(candidate => candidate.id === headingId);
 
   if (!heading) {
     return {

--- a/src/components/webmcp/lib/content-snapshot.ts
+++ b/src/components/webmcp/lib/content-snapshot.ts
@@ -49,6 +49,10 @@ function isShuffleLettersPathname(pathname: string) {
   );
 }
 
+function isContentType(value: string | undefined): value is ContentType {
+  return value === 'article' || value === 'craft';
+}
+
 export function getCurrentContentContext(docLike?: Document) {
   const doc = getDocument(docLike);
   const root = getContentRoot(doc);
@@ -57,6 +61,17 @@ export function getCurrentContentContext(docLike?: Document) {
     return {
       ok: false,
       error: '현재 페이지에는 WebMCP 콘텐츠 컨텍스트가 없습니다.',
+    } satisfies SnapshotFailure;
+  }
+
+  const type = root.dataset.webmcpContentType;
+  const slug = root.dataset.webmcpSlug;
+  const title = root.dataset.webmcpTitle;
+
+  if (!isContentType(type) || !slug || !title) {
+    return {
+      ok: false,
+      error: 'WebMCP 콘텐츠 메타데이터가 올바르지 않습니다.',
     } satisfies SnapshotFailure;
   }
 
@@ -79,9 +94,9 @@ export function getCurrentContentContext(docLike?: Document) {
 
   return {
     ok: true,
-    type: root.dataset.webmcpContentType as ContentType,
-    slug: root.dataset.webmcpSlug ?? '',
-    title: root.dataset.webmcpTitle ?? '',
+    type,
+    slug,
+    title,
     publishedAt: root.dataset.webmcpPublishedAt ?? '',
     description: root.dataset.webmcpDescription ?? '',
     summary: root.dataset.webmcpSummary ?? '',
@@ -161,9 +176,18 @@ export function getSeriesTargetHref(target: SeriesTarget, docLike?: Document) {
     } satisfies SnapshotFailure;
   }
 
+  const href = link.getAttribute('href');
+
+  if (!href) {
+    return {
+      ok: false,
+      error: `${target} 시리즈 이동 링크에 href가 없습니다.`,
+    } satisfies SnapshotFailure;
+  }
+
   return {
     ok: true,
-    href: link.getAttribute('href') ?? '',
+    href,
   };
 }
 

--- a/src/components/webmcp/lib/content-snapshot.ts
+++ b/src/components/webmcp/lib/content-snapshot.ts
@@ -1,0 +1,183 @@
+import type { WebMCPToolName } from '@/components/webmcp/lib/schemas';
+
+type ContentType = 'article' | 'craft';
+type SeriesTarget = 'series' | 'previous' | 'next';
+
+type HeadingSnapshot = {
+  id: string;
+  title: string;
+  level: 2 | 4;
+};
+
+type SnapshotFailure = {
+  ok: false;
+  error: string;
+};
+
+const contentSelector = '[data-webmcp-content]';
+const codeBlockSelector = 'pre[data-webmcp-code-block]';
+
+const baseActions: WebMCPToolName[] = [
+  'navigate_site',
+  'get_site_context',
+  'toggle_theme',
+  'set_sound',
+  'copy_current_url',
+  'find_content',
+  'open_content',
+  'list_page_actions',
+];
+
+function cleanText(value: string | null | undefined) {
+  return value?.replace(/\s+/g, ' ').trim() ?? '';
+}
+
+function getDocument(docLike: Document | undefined) {
+  return docLike ?? document;
+}
+
+function getContentRoot(doc: Document) {
+  return doc.querySelector<HTMLElement>(contentSelector);
+}
+
+export function getCurrentContentContext(docLike?: Document) {
+  const doc = getDocument(docLike);
+  const root = getContentRoot(doc);
+
+  if (!root) {
+    return {
+      ok: false,
+      error: '현재 페이지에는 WebMCP 콘텐츠 컨텍스트가 없습니다.',
+    } satisfies SnapshotFailure;
+  }
+
+  const article = root.querySelector('article');
+  const headings = [
+    ...root.querySelectorAll<HTMLElement>('article h2[id], article h4[id]'),
+  ]
+    .map(heading => ({
+      id: heading.id,
+      title: cleanText(heading.textContent),
+      level: Number(heading.tagName.slice(1)) as 2 | 4,
+    }))
+    .filter((heading): heading is HeadingSnapshot =>
+      Boolean(heading.id && heading.title)
+    );
+  const excerpt = cleanText(article?.querySelector('p')?.textContent).slice(
+    0,
+    300
+  );
+  const seriesId = root.dataset.webmcpSeriesId;
+  const seriesName = root.dataset.webmcpSeriesName;
+
+  return {
+    ok: true,
+    type: root.dataset.webmcpContentType as ContentType,
+    slug: root.dataset.webmcpSlug ?? '',
+    title: root.dataset.webmcpTitle ?? '',
+    publishedAt: root.dataset.webmcpPublishedAt ?? '',
+    description: root.dataset.webmcpDescription ?? '',
+    summary: root.dataset.webmcpSummary ?? '',
+    ...(seriesId &&
+      seriesName && {
+        series: {
+          id: seriesId,
+          name: seriesName,
+        },
+      }),
+    tldr: cleanText(root.querySelector('blockquote')?.textContent),
+    excerpt,
+    headings,
+  };
+}
+
+export function getCodeBlockText(index: number, docLike?: Document) {
+  const doc = getDocument(docLike);
+  const block = [...doc.querySelectorAll<HTMLElement>(codeBlockSelector)][
+    index
+  ];
+  const code = block?.querySelector('code');
+  const text = code?.textContent?.trim() ?? '';
+
+  if (!block || !text) {
+    return {
+      ok: false,
+      error: `${index}번 코드 블록을 찾지 못했습니다.`,
+    } satisfies SnapshotFailure;
+  }
+
+  const languageClass = [...(code?.classList ?? [])].find(className =>
+    className.startsWith('language-')
+  );
+
+  return {
+    ok: true,
+    language: languageClass?.replace('language-', '') ?? '',
+    text,
+    characterCount: text.length,
+  };
+}
+
+export function jumpToHeading(headingId: string, docLike?: Document) {
+  const doc = getDocument(docLike);
+  const heading = doc.getElementById(headingId);
+
+  if (!heading) {
+    return {
+      ok: false,
+      error: `${headingId} heading을 찾지 못했습니다.`,
+    } satisfies SnapshotFailure;
+  }
+
+  heading.scrollIntoView({ behavior: 'smooth', block: 'start' });
+
+  return {
+    ok: true,
+    headingId,
+    title: cleanText(heading.textContent),
+  };
+}
+
+export function getSeriesTargetHref(target: SeriesTarget, docLike?: Document) {
+  const doc = getDocument(docLike);
+  const link = doc.querySelector<HTMLAnchorElement>(
+    `[data-webmcp-series-target="${target}"]`
+  );
+
+  if (!link) {
+    return {
+      ok: false,
+      error: `${target} 시리즈 이동 링크를 찾지 못했습니다.`,
+    } satisfies SnapshotFailure;
+  }
+
+  return {
+    ok: true,
+    href: link.getAttribute('href') ?? '',
+  };
+}
+
+export function getPageActions(pathname: string, docLike?: Document) {
+  const doc = getDocument(docLike);
+  const actions = new Set<WebMCPToolName>(baseActions);
+
+  if (getContentRoot(doc)) {
+    actions.add('get_current_content_context');
+    actions.add('jump_to_heading');
+  }
+
+  if (doc.querySelector(codeBlockSelector)) {
+    actions.add('copy_code_block');
+  }
+
+  if (doc.querySelector('[data-webmcp-series-target]')) {
+    actions.add('open_series');
+  }
+
+  if (pathname.startsWith('/playground/shuffle-letters')) {
+    actions.add('run_shuffle_letters');
+    actions.add('stop_shuffle_letters');
+  }
+
+  return [...actions];
+}

--- a/src/components/webmcp/lib/content-snapshot.ts
+++ b/src/components/webmcp/lib/content-snapshot.ts
@@ -16,6 +16,7 @@ type SnapshotFailure = {
 
 const contentSelector = '[data-webmcp-content]';
 const codeBlockSelector = 'pre[data-webmcp-code-block]';
+const shuffleLettersPathname = '/playground/shuffle-letters';
 
 const baseActions: WebMCPToolName[] = [
   'navigate_site',
@@ -38,6 +39,13 @@ function getDocument(docLike: Document | undefined) {
 
 function getContentRoot(doc: Document) {
   return doc.querySelector<HTMLElement>(contentSelector);
+}
+
+function isShuffleLettersPathname(pathname: string) {
+  return (
+    pathname === shuffleLettersPathname ||
+    pathname === `${shuffleLettersPathname}/`
+  );
 }
 
 export function getCurrentContentContext(docLike?: Document) {
@@ -178,7 +186,7 @@ export function getPageActions(pathname: string, docLike?: Document) {
     actions.add('open_series');
   }
 
-  if (pathname.startsWith('/playground/shuffle-letters')) {
+  if (isShuffleLettersPathname(pathname)) {
     actions.add('run_shuffle_letters');
     actions.add('stop_shuffle_letters');
   }

--- a/src/components/webmcp/lib/content-snapshot.ts
+++ b/src/components/webmcp/lib/content-snapshot.ts
@@ -6,7 +6,7 @@ type SeriesTarget = 'series' | 'previous' | 'next';
 type HeadingSnapshot = {
   id: string;
   title: string;
-  level: 2 | 4;
+  level: 2 | 3 | 4;
 };
 
 type SnapshotFailure = {
@@ -16,6 +16,7 @@ type SnapshotFailure = {
 
 const contentSelector = '[data-webmcp-content]';
 const codeBlockSelector = 'pre[data-webmcp-code-block]';
+const headingSelector = 'article h2[id], article h3[id], article h4[id]';
 const shuffleLettersPathname = '/playground/shuffle-letters';
 
 const baseActions: WebMCPToolName[] = [
@@ -60,13 +61,11 @@ export function getCurrentContentContext(docLike?: Document) {
   }
 
   const article = root.querySelector('article');
-  const headings = [
-    ...root.querySelectorAll<HTMLElement>('article h2[id], article h4[id]'),
-  ]
+  const headings = [...root.querySelectorAll<HTMLElement>(headingSelector)]
     .map(heading => ({
       id: heading.id,
       title: cleanText(heading.textContent),
-      level: Number(heading.tagName.slice(1)) as 2 | 4,
+      level: Number(heading.tagName.slice(1)) as 2 | 3 | 4,
     }))
     .filter((heading): heading is HeadingSnapshot =>
       Boolean(heading.id && heading.title)
@@ -130,8 +129,7 @@ export function jumpToHeading(headingId: string, docLike?: Document) {
   const doc = getDocument(docLike);
   const root = getContentRoot(doc);
   const heading = [
-    ...(root?.querySelectorAll<HTMLElement>('article h2[id], article h4[id]') ??
-      []),
+    ...(root?.querySelectorAll<HTMLElement>(headingSelector) ?? []),
   ].find(candidate => candidate.id === headingId);
 
   if (!heading) {

--- a/src/components/webmcp/lib/register-tool.spec.ts
+++ b/src/components/webmcp/lib/register-tool.spec.ts
@@ -1,3 +1,4 @@
+/* eslint-disable playwright/no-standalone-expect */
 import { describe, expect, it, vi } from 'vitest';
 
 import {

--- a/src/components/webmcp/lib/register-tool.spec.ts
+++ b/src/components/webmcp/lib/register-tool.spec.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it, vi } from 'vitest';
 
+import {
+  createToolDescriptor,
+  webMCPSchemas,
+} from '@/components/webmcp/lib/schemas';
 import { hasModelContext, registerWebMCPTools } from '@/components/webmcp/lib/register-tool';
 import type { WebMCPToolDescriptor } from '@/components/webmcp/types/webmcp';
 
@@ -80,6 +84,21 @@ describe('registerWebMCPTools', () => {
 
   it('does nothing and returns a stable cleanup function when unsupported', () => {
     const cleanup = registerWebMCPTools([createTool('get_site_context')], {
+      modelContext: undefined,
+    } as unknown as Navigator);
+
+    expect(() => cleanup()).not.toThrow();
+  });
+
+  it('accepts strongly typed tool descriptors from createToolDescriptor', () => {
+    const typedTool = createToolDescriptor<{ enabled: boolean }, string>({
+      name: 'set_sound',
+      description: 'Set sound preference.',
+      inputSchema: webMCPSchemas.setSound,
+      execute: input => (input.enabled ? 'enabled' : 'disabled'),
+    });
+
+    const cleanup = registerWebMCPTools([typedTool], {
       modelContext: undefined,
     } as unknown as Navigator);
 

--- a/src/components/webmcp/lib/register-tool.spec.ts
+++ b/src/components/webmcp/lib/register-tool.spec.ts
@@ -55,6 +55,29 @@ describe('registerWebMCPTools', () => {
     expect(firstOptions.signal.aborted).toBe(true);
   });
 
+  it('aborts already registered tools when a later registration throws', () => {
+    const registerError = new Error('register failed');
+    const registerTool = vi
+      .fn()
+      .mockImplementationOnce(() => {})
+      .mockImplementationOnce(() => {
+        throw registerError;
+      });
+    const navigatorMock = {
+      modelContext: { registerTool },
+    } as unknown as Navigator;
+    const tools = [createTool('get_site_context'), createTool('navigate_site')];
+
+    expect(() => registerWebMCPTools(tools, navigatorMock)).toThrow(
+      registerError
+    );
+
+    const firstOptions = registerTool.mock.calls[0][1] as {
+      signal: AbortSignal;
+    };
+    expect(firstOptions.signal.aborted).toBe(true);
+  });
+
   it('does nothing and returns a stable cleanup function when unsupported', () => {
     const cleanup = registerWebMCPTools([createTool('get_site_context')], {
       modelContext: undefined,

--- a/src/components/webmcp/lib/register-tool.spec.ts
+++ b/src/components/webmcp/lib/register-tool.spec.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { hasModelContext, registerWebMCPTools } from './register-tool';
+import type { WebMCPToolDescriptor } from '../types/webmcp';
+
+function createTool(name: string): WebMCPToolDescriptor {
+  return {
+    name,
+    description: `${name} description`,
+    inputSchema: {
+      type: 'object',
+      properties: {},
+      additionalProperties: false,
+    },
+    execute: vi.fn(),
+  };
+}
+
+describe('registerWebMCPTools', () => {
+  it('returns false when navigator.modelContext is missing', () => {
+    expect(hasModelContext({} as Navigator)).toBe(false);
+  });
+
+  it('returns true when navigator.modelContext.registerTool exists', () => {
+    expect(
+      hasModelContext({
+        modelContext: {
+          registerTool: vi.fn(),
+        },
+      } as unknown as Navigator)
+    ).toBe(true);
+  });
+
+  it('registers each tool with one abort signal and cleans up by aborting it', () => {
+    const registerTool = vi.fn();
+    const navigatorMock = {
+      modelContext: { registerTool },
+    } as unknown as Navigator;
+    const tools = [createTool('get_site_context'), createTool('navigate_site')];
+
+    const cleanup = registerWebMCPTools(tools, navigatorMock);
+
+    expect(registerTool).toHaveBeenCalledTimes(2);
+    const firstOptions = registerTool.mock.calls[0][1] as {
+      signal: AbortSignal;
+    };
+    const secondOptions = registerTool.mock.calls[1][1] as {
+      signal: AbortSignal;
+    };
+    expect(firstOptions.signal).toBe(secondOptions.signal);
+    expect(firstOptions.signal.aborted).toBe(false);
+
+    cleanup();
+
+    expect(firstOptions.signal.aborted).toBe(true);
+  });
+
+  it('does nothing and returns a stable cleanup function when unsupported', () => {
+    const cleanup = registerWebMCPTools([createTool('get_site_context')], {
+      modelContext: undefined,
+    } as unknown as Navigator);
+
+    expect(() => cleanup()).not.toThrow();
+  });
+});

--- a/src/components/webmcp/lib/register-tool.spec.ts
+++ b/src/components/webmcp/lib/register-tool.spec.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it, vi } from 'vitest';
 
-import { hasModelContext, registerWebMCPTools } from './register-tool';
-import type { WebMCPToolDescriptor } from '../types/webmcp';
+import { hasModelContext, registerWebMCPTools } from '@/components/webmcp/lib/register-tool';
+import type { WebMCPToolDescriptor } from '@/components/webmcp/types/webmcp';
 
 function createTool(name: string): WebMCPToolDescriptor {
   return {

--- a/src/components/webmcp/lib/register-tool.spec.ts
+++ b/src/components/webmcp/lib/register-tool.spec.ts
@@ -4,7 +4,10 @@ import {
   createToolDescriptor,
   webMCPSchemas,
 } from '@/components/webmcp/lib/schemas';
-import { hasModelContext, registerWebMCPTools } from '@/components/webmcp/lib/register-tool';
+import {
+  hasModelContext,
+  registerWebMCPTools,
+} from '@/components/webmcp/lib/register-tool';
 import type { WebMCPToolDescriptor } from '@/components/webmcp/types/webmcp';
 
 function createTool(name: string): WebMCPToolDescriptor {

--- a/src/components/webmcp/lib/register-tool.ts
+++ b/src/components/webmcp/lib/register-tool.ts
@@ -22,10 +22,15 @@ export function registerWebMCPTools(
 
   const controller = new AbortController();
 
-  for (const tool of tools) {
-    navigatorLike.modelContext.registerTool(tool, {
-      signal: controller.signal,
-    });
+  try {
+    for (const tool of tools) {
+      navigatorLike.modelContext.registerTool(tool, {
+        signal: controller.signal,
+      });
+    }
+  } catch (error) {
+    controller.abort();
+    throw error;
   }
 
   return () => {

--- a/src/components/webmcp/lib/register-tool.ts
+++ b/src/components/webmcp/lib/register-tool.ts
@@ -1,4 +1,4 @@
-import type { WebMCPToolDescriptor } from '@/components/webmcp/types/webmcp';
+import type { AnyWebMCPToolDescriptor } from '@/components/webmcp/types/webmcp';
 
 const noop = () => {};
 
@@ -12,7 +12,7 @@ export function hasModelContext(
 }
 
 export function registerWebMCPTools(
-  tools: readonly WebMCPToolDescriptor[],
+  tools: readonly AnyWebMCPToolDescriptor[],
   navigatorLike: Navigator | undefined =
     typeof navigator === 'undefined' ? undefined : navigator
 ) {

--- a/src/components/webmcp/lib/register-tool.ts
+++ b/src/components/webmcp/lib/register-tool.ts
@@ -1,0 +1,34 @@
+import type { WebMCPToolDescriptor } from '@/components/webmcp/types/webmcp';
+
+const noop = () => {};
+
+export function hasModelContext(
+  navigatorLike: Navigator | undefined =
+    typeof navigator === 'undefined' ? undefined : navigator
+): navigatorLike is Navigator & {
+  modelContext: NonNullable<Navigator['modelContext']>;
+} {
+  return typeof navigatorLike?.modelContext?.registerTool === 'function';
+}
+
+export function registerWebMCPTools(
+  tools: readonly WebMCPToolDescriptor[],
+  navigatorLike: Navigator | undefined =
+    typeof navigator === 'undefined' ? undefined : navigator
+) {
+  if (!hasModelContext(navigatorLike)) {
+    return noop;
+  }
+
+  const controller = new AbortController();
+
+  for (const tool of tools) {
+    navigatorLike.modelContext.registerTool(tool, {
+      signal: controller.signal,
+    });
+  }
+
+  return () => {
+    controller.abort();
+  };
+}

--- a/src/components/webmcp/lib/register-tool.ts
+++ b/src/components/webmcp/lib/register-tool.ts
@@ -3,8 +3,9 @@ import type { AnyWebMCPToolDescriptor } from '@/components/webmcp/types/webmcp';
 const noop = () => {};
 
 export function hasModelContext(
-  navigatorLike: Navigator | undefined =
-    typeof navigator === 'undefined' ? undefined : navigator
+  navigatorLike: Navigator | undefined = typeof navigator === 'undefined'
+    ? undefined
+    : navigator
 ): navigatorLike is Navigator & {
   modelContext: NonNullable<Navigator['modelContext']>;
 } {
@@ -13,8 +14,9 @@ export function hasModelContext(
 
 export function registerWebMCPTools(
   tools: readonly AnyWebMCPToolDescriptor[],
-  navigatorLike: Navigator | undefined =
-    typeof navigator === 'undefined' ? undefined : navigator
+  navigatorLike: Navigator | undefined = typeof navigator === 'undefined'
+    ? undefined
+    : navigator
 ) {
   if (!hasModelContext(navigatorLike)) {
     return noop;

--- a/src/components/webmcp/lib/schemas.ts
+++ b/src/components/webmcp/lib/schemas.ts
@@ -1,5 +1,6 @@
 import type {
   WebMCPJSONSchema,
+  WebMCPModelContextClient,
   WebMCPToolAnnotations,
   WebMCPToolDescriptor,
 } from '@/components/webmcp/types/webmcp';
@@ -122,19 +123,25 @@ export const webMCPSchemas = {
 
 export function createToolDescriptor<Input, Output>({
   name,
+  title,
   description,
   inputSchema,
   annotations,
   execute,
 }: {
   name: WebMCPToolName;
+  title?: string;
   description: string;
   inputSchema: WebMCPJSONSchema;
   annotations?: WebMCPToolAnnotations;
-  execute: (input: Input) => Output | Promise<Output>;
+  execute: (
+    input: Input,
+    client: WebMCPModelContextClient
+  ) => Output | Promise<Output>;
 }): WebMCPToolDescriptor<Input, Output> {
   return {
     name,
+    title,
     description,
     inputSchema,
     annotations,

--- a/src/components/webmcp/lib/schemas.ts
+++ b/src/components/webmcp/lib/schemas.ts
@@ -1,0 +1,143 @@
+import type {
+  WebMCPJSONSchema,
+  WebMCPToolAnnotations,
+  WebMCPToolDescriptor,
+} from '@/components/webmcp/types/webmcp';
+
+export type WebMCPToolName =
+  | 'navigate_site'
+  | 'get_site_context'
+  | 'toggle_theme'
+  | 'set_sound'
+  | 'copy_current_url'
+  | 'find_content'
+  | 'open_content'
+  | 'get_current_content_context'
+  | 'open_series'
+  | 'jump_to_heading'
+  | 'copy_code_block'
+  | 'list_page_actions'
+  | 'run_shuffle_letters'
+  | 'stop_shuffle_letters';
+
+export const emptyObjectSchema = {
+  type: 'object',
+  properties: {},
+  additionalProperties: false,
+} satisfies WebMCPJSONSchema;
+
+const stringSchema = {
+  type: 'string',
+} satisfies WebMCPJSONSchema;
+
+const numberSchema = (minimum: number, maximum: number) =>
+  ({
+    type: 'number',
+    minimum,
+    maximum,
+  }) satisfies WebMCPJSONSchema;
+
+const enumSchema = (values: readonly string[]) =>
+  ({
+    type: 'string',
+    enum: values,
+  }) satisfies WebMCPJSONSchema;
+
+export const webMCPSchemas = {
+  navigateSite: {
+    type: 'object',
+    properties: {
+      destination: enumSchema([
+        'home',
+        'article',
+        'craft',
+        'shuffle-playground',
+      ]),
+    },
+    required: ['destination'],
+    additionalProperties: false,
+  },
+  setSound: {
+    type: 'object',
+    properties: {
+      enabled: { type: 'boolean' },
+    },
+    required: ['enabled'],
+    additionalProperties: false,
+  },
+  findContent: {
+    type: 'object',
+    properties: {
+      query: stringSchema,
+      type: enumSchema(['all', 'article', 'craft']),
+      limit: numberSchema(1, 10),
+    },
+    required: ['query'],
+    additionalProperties: false,
+  },
+  openContent: {
+    type: 'object',
+    properties: {
+      type: enumSchema(['article', 'craft']),
+      slug: stringSchema,
+    },
+    required: ['type', 'slug'],
+    additionalProperties: false,
+  },
+  openSeries: {
+    type: 'object',
+    properties: {
+      target: enumSchema(['series', 'previous', 'next']),
+    },
+    required: ['target'],
+    additionalProperties: false,
+  },
+  jumpToHeading: {
+    type: 'object',
+    properties: {
+      headingId: stringSchema,
+    },
+    required: ['headingId'],
+    additionalProperties: false,
+  },
+  copyCodeBlock: {
+    type: 'object',
+    properties: {
+      index: numberSchema(0, 999),
+    },
+    required: ['index'],
+    additionalProperties: false,
+  },
+  runShuffleLetters: {
+    type: 'object',
+    properties: {
+      text: stringSchema,
+      iterations: numberSchema(1, 50),
+      fps: numberSchema(1, 60),
+    },
+    required: ['text', 'iterations', 'fps'],
+    additionalProperties: false,
+  },
+} satisfies Record<string, WebMCPJSONSchema>;
+
+export function createToolDescriptor<Input, Output>({
+  name,
+  description,
+  inputSchema,
+  annotations,
+  execute,
+}: {
+  name: WebMCPToolName;
+  description: string;
+  inputSchema: WebMCPJSONSchema;
+  annotations?: WebMCPToolAnnotations;
+  execute: (input: Input) => Output | Promise<Output>;
+}): WebMCPToolDescriptor<Input, Output> {
+  return {
+    name,
+    description,
+    inputSchema,
+    annotations,
+    execute,
+  };
+}

--- a/src/components/webmcp/model/tool-handlers.spec.ts
+++ b/src/components/webmcp/model/tool-handlers.spec.ts
@@ -216,7 +216,7 @@ describe('createWebMCPHandlers', () => {
       'https://bendd.me/article/agentic-interfaces'
     );
     expect(writeText).toHaveBeenCalledWith('const value = 1;');
-    expect(handlers.copyCodeBlock({ index: -1 })).resolves.toEqual({
+    await expect(handlers.copyCodeBlock({ index: -1 })).resolves.toEqual({
       ok: false,
       error: 'index는 0 이상의 숫자여야 합니다.',
     });
@@ -283,6 +283,54 @@ describe('createWebMCPHandlers', () => {
     expect(dispatchWindowEvent).toHaveBeenCalledWith(
       'webmcp:stop-shuffle-letters'
     );
+  });
+
+  it('rejects runShuffleLetters outside the shuffle playground without dispatching', () => {
+    const dispatchWindowEvent = vi.fn();
+    const handlers = createWebMCPHandlers({
+      pathname: '/article/agentic-interfaces',
+      router: { push },
+      getTheme: () => 'light',
+      setTheme,
+      getSoundEnabled: () => false,
+      setSoundEnabled,
+      getCurrentHref: () => 'https://bendd.me/article/agentic-interfaces',
+      document,
+      clipboard: { writeText },
+      fetchContentIndex: async () => [],
+      dispatchWindowEvent,
+    });
+
+    expect(
+      handlers.runShuffleLetters({ text: 'Hello', iterations: 8, fps: 30 })
+    ).toEqual({
+      ok: false,
+      error: 'shuffle letters 페이지에서만 실행할 수 있습니다.',
+    });
+    expect(dispatchWindowEvent).not.toHaveBeenCalled();
+  });
+
+  it('rejects stopShuffleLetters outside the shuffle playground without dispatching', () => {
+    const dispatchWindowEvent = vi.fn();
+    const handlers = createWebMCPHandlers({
+      pathname: '/article/agentic-interfaces',
+      router: { push },
+      getTheme: () => 'light',
+      setTheme,
+      getSoundEnabled: () => false,
+      setSoundEnabled,
+      getCurrentHref: () => 'https://bendd.me/article/agentic-interfaces',
+      document,
+      clipboard: { writeText },
+      fetchContentIndex: async () => [],
+      dispatchWindowEvent,
+    });
+
+    expect(handlers.stopShuffleLetters()).toEqual({
+      ok: false,
+      error: 'shuffle letters 페이지에서만 실행할 수 있습니다.',
+    });
+    expect(dispatchWindowEvent).not.toHaveBeenCalled();
   });
 });
 

--- a/src/components/webmcp/model/tool-handlers.spec.ts
+++ b/src/components/webmcp/model/tool-handlers.spec.ts
@@ -222,6 +222,22 @@ describe('createWebMCPHandlers', () => {
     });
   });
 
+  it('returns structured failures when clipboard writes reject', async () => {
+    const handlers = createHandlers();
+
+    writeText.mockRejectedValueOnce(new DOMException('Denied'));
+    await expect(handlers.copyCurrentUrl()).resolves.toEqual({
+      ok: false,
+      error: '현재 URL을 클립보드에 복사하지 못했습니다.',
+    });
+
+    writeText.mockRejectedValueOnce(new DOMException('Denied'));
+    await expect(handlers.copyCodeBlock({ index: 0 })).resolves.toEqual({
+      ok: false,
+      error: '코드 블록을 클립보드에 복사하지 못했습니다.',
+    });
+  });
+
   it('returns page actions for the current route', () => {
     const handlers = createHandlers();
 

--- a/src/components/webmcp/model/tool-handlers.spec.ts
+++ b/src/components/webmcp/model/tool-handlers.spec.ts
@@ -40,6 +40,7 @@ describe('createWebMCPHandlers', () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+    document.execCommand = vi.fn(() => false);
     document.head.innerHTML = `
       <title>Agentic interfaces</title>
       <link rel="canonical" href="https://bendd.me/article/agentic-interfaces">
@@ -236,6 +237,29 @@ describe('createWebMCPHandlers', () => {
       ok: false,
       error: '코드 블록을 클립보드에 복사하지 못했습니다.',
     });
+  });
+
+  it('falls back to selection copy when the async clipboard is denied', async () => {
+    const handlers = createHandlers();
+
+    writeText.mockRejectedValueOnce(new DOMException('Denied'));
+    vi.mocked(document.execCommand).mockReturnValueOnce(true);
+
+    await expect(handlers.copyCurrentUrl()).resolves.toEqual({
+      ok: true,
+      href: 'https://bendd.me/article/agentic-interfaces',
+    });
+    expect(document.execCommand).toHaveBeenCalledWith('copy');
+
+    writeText.mockRejectedValueOnce(new DOMException('Denied'));
+    vi.mocked(document.execCommand).mockReturnValueOnce(true);
+
+    await expect(handlers.copyCodeBlock({ index: 0 })).resolves.toEqual({
+      ok: true,
+      language: 'ts',
+      characterCount: 16,
+    });
+    expect(document.execCommand).toHaveBeenCalledWith('copy');
   });
 
   it('returns page actions for the current route', () => {

--- a/src/components/webmcp/model/tool-handlers.spec.ts
+++ b/src/components/webmcp/model/tool-handlers.spec.ts
@@ -310,6 +310,32 @@ describe('createWebMCPHandlers', () => {
     expect(dispatchWindowEvent).not.toHaveBeenCalled();
   });
 
+  it('rejects runShuffleLetters on sibling-prefix paths without dispatching', () => {
+    const dispatchWindowEvent = vi.fn();
+    const handlers = createWebMCPHandlers({
+      pathname: '/playground/shuffle-letters-preview',
+      router: { push },
+      getTheme: () => 'light',
+      setTheme,
+      getSoundEnabled: () => false,
+      setSoundEnabled,
+      getCurrentHref: () =>
+        'https://bendd.me/playground/shuffle-letters-preview',
+      document,
+      clipboard: { writeText },
+      fetchContentIndex: async () => [],
+      dispatchWindowEvent,
+    });
+
+    expect(
+      handlers.runShuffleLetters({ text: 'Hello', iterations: 8, fps: 30 })
+    ).toEqual({
+      ok: false,
+      error: 'shuffle letters 페이지에서만 실행할 수 있습니다.',
+    });
+    expect(dispatchWindowEvent).not.toHaveBeenCalled();
+  });
+
   it('rejects stopShuffleLetters outside the shuffle playground without dispatching', () => {
     const dispatchWindowEvent = vi.fn();
     const handlers = createWebMCPHandlers({
@@ -320,6 +346,30 @@ describe('createWebMCPHandlers', () => {
       getSoundEnabled: () => false,
       setSoundEnabled,
       getCurrentHref: () => 'https://bendd.me/article/agentic-interfaces',
+      document,
+      clipboard: { writeText },
+      fetchContentIndex: async () => [],
+      dispatchWindowEvent,
+    });
+
+    expect(handlers.stopShuffleLetters()).toEqual({
+      ok: false,
+      error: 'shuffle letters 페이지에서만 실행할 수 있습니다.',
+    });
+    expect(dispatchWindowEvent).not.toHaveBeenCalled();
+  });
+
+  it('rejects stopShuffleLetters on sibling-prefix paths without dispatching', () => {
+    const dispatchWindowEvent = vi.fn();
+    const handlers = createWebMCPHandlers({
+      pathname: '/playground/shuffle-letters-preview',
+      router: { push },
+      getTheme: () => 'light',
+      setTheme,
+      getSoundEnabled: () => false,
+      setSoundEnabled,
+      getCurrentHref: () =>
+        'https://bendd.me/playground/shuffle-letters-preview',
       document,
       clipboard: { writeText },
       fetchContentIndex: async () => [],

--- a/src/components/webmcp/model/tool-handlers.spec.ts
+++ b/src/components/webmcp/model/tool-handlers.spec.ts
@@ -427,4 +427,24 @@ describe('createLazyContentIndexFetcher', () => {
       'WebMCP 콘텐츠 인덱스를 불러오지 못했습니다.'
     );
   });
+
+  it('clears a failed fetch so a later call can retry', async () => {
+    const fetcher = vi
+      .fn()
+      .mockResolvedValueOnce({
+        ok: false,
+        json: async () => ({ items: [] }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ items: [] }),
+      }) as unknown as typeof fetch;
+    const load = createLazyContentIndexFetcher(fetcher);
+
+    await expect(load()).rejects.toThrow(
+      'WebMCP 콘텐츠 인덱스를 불러오지 못했습니다.'
+    );
+    await expect(load()).resolves.toEqual([]);
+    expect(fetcher).toHaveBeenCalledTimes(2);
+  });
 });

--- a/src/components/webmcp/model/tool-handlers.spec.ts
+++ b/src/components/webmcp/model/tool-handlers.spec.ts
@@ -1,0 +1,316 @@
+/* eslint-disable playwright/no-standalone-expect */
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import {
+  createLazyContentIndexFetcher,
+  createWebMCPHandlers,
+} from '@/components/webmcp/model/tool-handlers';
+
+import type { WebMCPContentIndexItem } from '@/components/webmcp/lib/content-index';
+
+describe('createWebMCPHandlers', () => {
+  const push = vi.fn();
+  const setTheme = vi.fn();
+  const setSoundEnabled = vi.fn();
+  const writeText = vi.fn();
+
+  const contentIndex = [
+    {
+      type: 'article',
+      slug: 'agentic-interfaces',
+      title: 'Agentic interfaces',
+      summary: 'Agent UI notes',
+      description: 'How agents use visible interfaces.',
+      publishedAt: '2026-05-10',
+      category: 'ai',
+      href: '/article/agentic-interfaces',
+      series: { id: 'ai-agents', name: 'AI Agents', order: 1 },
+    },
+    {
+      type: 'craft',
+      slug: 'shuffle-letters',
+      title: 'Shuffle Letters',
+      summary: 'Animated text playground',
+      description: 'A craft note about animated letters.',
+      publishedAt: '2026-05-11',
+      category: 'playground',
+      href: '/craft/shuffle-letters',
+    },
+  ] satisfies WebMCPContentIndexItem[];
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    document.head.innerHTML = `
+      <title>Agentic interfaces</title>
+      <link rel="canonical" href="https://bendd.me/article/agentic-interfaces">
+    `;
+    document.body.innerHTML = `
+      <section
+        data-webmcp-content
+        data-webmcp-content-type="article"
+        data-webmcp-slug="agentic-interfaces"
+        data-webmcp-title="Agentic interfaces"
+        data-webmcp-published-at="2026-05-10"
+        data-webmcp-description="How agents use visible interfaces."
+        data-webmcp-summary="Agent UI notes"
+      >
+        <a href="/article/series/ai-agents" data-webmcp-series-target="series">Series</a>
+        <a href="/article/previous" data-webmcp-series-target="previous">Previous</a>
+        <article>
+          <p>First paragraph.</p>
+          <h2 id="overview">Overview</h2>
+          <pre data-webmcp-code-block><code class="language-ts">const value = 1;</code></pre>
+        </article>
+      </section>
+    `;
+  });
+
+  function createHandlers() {
+    return createWebMCPHandlers({
+      pathname: '/article/agentic-interfaces',
+      router: { push },
+      getTheme: () => 'dark',
+      setTheme,
+      getSoundEnabled: () => false,
+      setSoundEnabled,
+      getCurrentHref: () => 'https://bendd.me/article/agentic-interfaces',
+      document,
+      clipboard: { writeText },
+      fetchContentIndex: async () => contentIndex,
+      dispatchWindowEvent: vi.fn(),
+    });
+  }
+
+  it('navigates only to known internal destinations', () => {
+    const handlers = createHandlers();
+
+    expect(handlers.navigateSite({ destination: 'craft' })).toEqual({
+      ok: true,
+      href: '/craft',
+    });
+    expect(push).toHaveBeenCalledWith('/craft');
+    expect(handlers.navigateSite({ destination: 'external' })).toEqual({
+      ok: false,
+      error: '지원하지 않는 destination입니다.',
+    });
+  });
+
+  it('returns site context from the current document', () => {
+    const handlers = createHandlers();
+
+    expect(handlers.getSiteContext()).toEqual({
+      ok: true,
+      pathname: '/article/agentic-interfaces',
+      title: 'Agentic interfaces',
+      canonicalUrl: 'https://bendd.me/article/agentic-interfaces',
+      actions: [
+        'navigate_site',
+        'get_site_context',
+        'toggle_theme',
+        'set_sound',
+        'copy_current_url',
+        'find_content',
+        'open_content',
+        'list_page_actions',
+        'get_current_content_context',
+        'jump_to_heading',
+        'copy_code_block',
+        'open_series',
+      ],
+    });
+  });
+
+  it('toggles theme using the current resolved theme', () => {
+    const handlers = createHandlers();
+
+    expect(handlers.toggleTheme()).toEqual({
+      ok: true,
+      theme: 'light',
+    });
+    expect(setTheme).toHaveBeenCalledWith('light');
+  });
+
+  it('sets sound explicitly', () => {
+    const handlers = createHandlers();
+
+    expect(handlers.setSound({ enabled: true })).toEqual({
+      ok: true,
+      enabled: true,
+    });
+    expect(setSoundEnabled).toHaveBeenCalledWith(true);
+    expect(handlers.setSound({ enabled: 'yes' })).toEqual({
+      ok: false,
+      error: 'enabled boolean 값이 필요합니다.',
+    });
+  });
+
+  it('searches the lazy content index across content fields', async () => {
+    const handlers = createHandlers();
+
+    await expect(
+      handlers.findContent({ query: 'AI Agents', type: 'all', limit: 5 })
+    ).resolves.toEqual({
+      ok: true,
+      items: [contentIndex[0]],
+    });
+    await expect(
+      handlers.findContent({ query: 'agent', type: 'video', limit: 5 })
+    ).resolves.toEqual({
+      ok: false,
+      error: 'type은 all, article, craft 중 하나여야 합니다.',
+    });
+  });
+
+  it('opens content found in the lazy content index', async () => {
+    const handlers = createHandlers();
+
+    await expect(
+      handlers.openContent({ type: 'article', slug: 'agentic-interfaces' })
+    ).resolves.toEqual({
+      ok: true,
+      href: '/article/agentic-interfaces',
+    });
+    expect(push).toHaveBeenCalledWith('/article/agentic-interfaces');
+    await expect(
+      handlers.openContent({ type: 'article', slug: 'missing' })
+    ).resolves.toEqual({
+      ok: false,
+      error: 'article/missing 콘텐츠를 찾지 못했습니다.',
+    });
+  });
+
+  it('delegates article helpers to snapshot utilities', () => {
+    const handlers = createHandlers();
+    const heading = document.getElementById('overview') as HTMLElement;
+    heading.scrollIntoView = vi.fn();
+
+    expect(handlers.getCurrentContentContext()).toMatchObject({
+      ok: true,
+      slug: 'agentic-interfaces',
+    });
+    expect(handlers.openSeries({ target: 'series' })).toEqual({
+      ok: true,
+      href: '/article/series/ai-agents',
+    });
+    expect(push).toHaveBeenCalledWith('/article/series/ai-agents');
+    expect(handlers.jumpToHeading({ headingId: 'overview' })).toEqual({
+      ok: true,
+      headingId: 'overview',
+      title: 'Overview',
+    });
+  });
+
+  it('copies current url and code block text through the clipboard dependency', async () => {
+    const handlers = createHandlers();
+
+    await expect(handlers.copyCurrentUrl()).resolves.toEqual({
+      ok: true,
+      href: 'https://bendd.me/article/agentic-interfaces',
+    });
+    await expect(handlers.copyCodeBlock({ index: 0 })).resolves.toEqual({
+      ok: true,
+      language: 'ts',
+      characterCount: 16,
+    });
+    expect(writeText).toHaveBeenCalledWith(
+      'https://bendd.me/article/agentic-interfaces'
+    );
+    expect(writeText).toHaveBeenCalledWith('const value = 1;');
+    expect(handlers.copyCodeBlock({ index: -1 })).resolves.toEqual({
+      ok: false,
+      error: 'index는 0 이상의 숫자여야 합니다.',
+    });
+  });
+
+  it('returns page actions for the current route', () => {
+    const handlers = createHandlers();
+
+    expect(handlers.listPageActions()).toEqual({
+      ok: true,
+      actions: [
+        'navigate_site',
+        'get_site_context',
+        'toggle_theme',
+        'set_sound',
+        'copy_current_url',
+        'find_content',
+        'open_content',
+        'list_page_actions',
+        'get_current_content_context',
+        'jump_to_heading',
+        'copy_code_block',
+        'open_series',
+      ],
+    });
+  });
+
+  it('dispatches shuffle events after validating bounds', () => {
+    const dispatchWindowEvent = vi.fn();
+    const handlers = createWebMCPHandlers({
+      pathname: '/playground/shuffle-letters',
+      router: { push },
+      getTheme: () => 'light',
+      setTheme,
+      getSoundEnabled: () => false,
+      setSoundEnabled,
+      getCurrentHref: () => 'https://bendd.me/playground/shuffle-letters',
+      document,
+      clipboard: { writeText },
+      fetchContentIndex: async () => [],
+      dispatchWindowEvent,
+    });
+
+    expect(
+      handlers.runShuffleLetters({ text: 'Hello', iterations: 8, fps: 30 })
+    ).toEqual({
+      ok: true,
+      text: 'Hello',
+      iterations: 8,
+      fps: 30,
+    });
+    expect(dispatchWindowEvent).toHaveBeenCalledWith(
+      'webmcp:run-shuffle-letters',
+      { text: 'Hello', iterations: 8, fps: 30 }
+    );
+    expect(
+      handlers.runShuffleLetters({ text: 'Hello', iterations: 99, fps: 30 })
+    ).toEqual({
+      ok: false,
+      error: 'iterations는 1에서 50 사이여야 합니다.',
+    });
+
+    expect(handlers.stopShuffleLetters()).toEqual({ ok: true });
+    expect(dispatchWindowEvent).toHaveBeenCalledWith(
+      'webmcp:stop-shuffle-letters'
+    );
+  });
+});
+
+describe('createLazyContentIndexFetcher', () => {
+  it('fetches the index once and reuses the in-memory promise', async () => {
+    const fetcher = vi.fn(async () => ({
+      ok: true,
+      json: async () => ({ items: [{ slug: 'one' }] }),
+    })) as unknown as typeof fetch;
+
+    const load = createLazyContentIndexFetcher(fetcher);
+
+    await expect(load()).resolves.toEqual([{ slug: 'one' }]);
+    await expect(load()).resolves.toEqual([{ slug: 'one' }]);
+    expect(fetcher).toHaveBeenCalledTimes(1);
+    expect(fetcher).toHaveBeenCalledWith('/api/webmcp/content-index');
+  });
+
+  it('propagates a Korean error when the response fails', async () => {
+    const fetcher = vi.fn(async () => ({
+      ok: false,
+      json: async () => ({ items: [] }),
+    })) as unknown as typeof fetch;
+
+    const load = createLazyContentIndexFetcher(fetcher);
+
+    await expect(load()).rejects.toThrow(
+      'WebMCP 콘텐츠 인덱스를 불러오지 못했습니다.'
+    );
+  });
+});

--- a/src/components/webmcp/model/tool-handlers.ts
+++ b/src/components/webmcp/model/tool-handlers.ts
@@ -96,7 +96,10 @@ function includesText(item: WebMCPContentIndexItem, query: string) {
 }
 
 function isShuffleLettersPathname(pathname: string) {
-  return pathname.startsWith(shuffleLettersPathname);
+  return (
+    pathname === shuffleLettersPathname ||
+    pathname === `${shuffleLettersPathname}/`
+  );
 }
 
 export function createLazyContentIndexFetcher(fetcher: typeof fetch = fetch) {

--- a/src/components/webmcp/model/tool-handlers.ts
+++ b/src/components/webmcp/model/tool-handlers.ts
@@ -102,6 +102,51 @@ function isShuffleLettersPathname(pathname: string) {
   );
 }
 
+function copyTextWithSelection(text: string, doc: Document) {
+  if (!doc.body || typeof doc.execCommand !== 'function') {
+    return false;
+  }
+
+  const textarea = doc.createElement('textarea');
+  textarea.value = text;
+  textarea.setAttribute('readonly', '');
+  textarea.style.position = 'fixed';
+  textarea.style.top = '0';
+  textarea.style.left = '0';
+  textarea.style.opacity = '0';
+  doc.body.appendChild(textarea);
+
+  try {
+    textarea.focus();
+    textarea.select();
+    return doc.execCommand('copy');
+  } finally {
+    textarea.remove();
+  }
+}
+
+async function writeClipboardText(
+  text: string,
+  {
+    clipboard,
+    document: doc,
+  }: {
+    clipboard?: ClipboardLike;
+    document: Document;
+  }
+) {
+  if (clipboard) {
+    try {
+      await clipboard.writeText(text);
+      return true;
+    } catch {
+      return copyTextWithSelection(text, doc);
+    }
+  }
+
+  return copyTextWithSelection(text, doc);
+}
+
 export function createLazyContentIndexFetcher(fetcher: typeof fetch = fetch) {
   let cached: Promise<WebMCPContentIndexItem[]> | undefined;
 
@@ -172,13 +217,12 @@ export function createWebMCPHandlers(deps: WebMCPHandlerDeps) {
     async copyCurrentUrl() {
       const href = deps.getCurrentHref();
 
-      if (!deps.clipboard) {
-        return fail('클립보드 API를 사용할 수 없습니다.');
-      }
-
-      try {
-        await deps.clipboard.writeText(href);
-      } catch {
+      if (
+        !(await writeClipboardText(href, {
+          clipboard: deps.clipboard,
+          document: deps.document,
+        }))
+      ) {
         return fail('현재 URL을 클립보드에 복사하지 못했습니다.');
       }
 
@@ -281,13 +325,12 @@ export function createWebMCPHandlers(deps: WebMCPHandlerDeps) {
         return result;
       }
 
-      if (!deps.clipboard) {
-        return fail('클립보드 API를 사용할 수 없습니다.');
-      }
-
-      try {
-        await deps.clipboard.writeText(result.text);
-      } catch {
+      if (
+        !(await writeClipboardText(result.text, {
+          clipboard: deps.clipboard,
+          document: deps.document,
+        }))
+      ) {
         return fail('코드 블록을 클립보드에 복사하지 못했습니다.');
       }
 

--- a/src/components/webmcp/model/tool-handlers.ts
+++ b/src/components/webmcp/model/tool-handlers.ts
@@ -172,7 +172,12 @@ export function createWebMCPHandlers(deps: WebMCPHandlerDeps) {
         return fail('클립보드 API를 사용할 수 없습니다.');
       }
 
-      await deps.clipboard.writeText(href);
+      try {
+        await deps.clipboard.writeText(href);
+      } catch {
+        return fail('현재 URL을 클립보드에 복사하지 못했습니다.');
+      }
+
       return { ok: true, href };
     },
 
@@ -276,7 +281,12 @@ export function createWebMCPHandlers(deps: WebMCPHandlerDeps) {
         return fail('클립보드 API를 사용할 수 없습니다.');
       }
 
-      await deps.clipboard.writeText(result.text);
+      try {
+        await deps.clipboard.writeText(result.text);
+      } catch {
+        return fail('코드 블록을 클립보드에 복사하지 못했습니다.');
+      }
+
       return {
         ok: true,
         language: result.language,

--- a/src/components/webmcp/model/tool-handlers.ts
+++ b/src/components/webmcp/model/tool-handlers.ts
@@ -114,7 +114,11 @@ export function createLazyContentIndexFetcher(fetcher: typeof fetch = fetch) {
 
         return response.json();
       })
-      .then((body: { items?: WebMCPContentIndexItem[] }) => body.items ?? []);
+      .then((body: { items?: WebMCPContentIndexItem[] }) => body.items ?? [])
+      .catch(error => {
+        cached = undefined;
+        throw error;
+      });
 
     return cached;
   };

--- a/src/components/webmcp/model/tool-handlers.ts
+++ b/src/components/webmcp/model/tool-handlers.ts
@@ -42,6 +42,7 @@ const destinations = {
   craft: '/craft',
   'shuffle-playground': '/playground/shuffle-letters',
 } as const;
+const shuffleLettersPathname = '/playground/shuffle-letters';
 
 function isRecord(input: unknown): input is Record<string, unknown> {
   return typeof input === 'object' && input !== null;
@@ -92,6 +93,10 @@ function includesText(item: WebMCPContentIndexItem, query: string) {
     .toLowerCase();
 
   return haystack.includes(query.toLowerCase());
+}
+
+function isShuffleLettersPathname(pathname: string) {
+  return pathname.startsWith(shuffleLettersPathname);
 }
 
 export function createLazyContentIndexFetcher(fetcher: typeof fetch = fetch) {
@@ -284,6 +289,10 @@ export function createWebMCPHandlers(deps: WebMCPHandlerDeps) {
     },
 
     runShuffleLetters(input: unknown) {
+      if (!isShuffleLettersPathname(deps.pathname)) {
+        return fail('shuffle letters 페이지에서만 실행할 수 있습니다.');
+      }
+
       const text = readString(input, 'text')?.trim();
       const iterations = readNumber(input, 'iterations');
       const fps = readNumber(input, 'fps');
@@ -315,6 +324,10 @@ export function createWebMCPHandlers(deps: WebMCPHandlerDeps) {
     },
 
     stopShuffleLetters() {
+      if (!isShuffleLettersPathname(deps.pathname)) {
+        return fail('shuffle letters 페이지에서만 실행할 수 있습니다.');
+      }
+
       deps.dispatchWindowEvent('webmcp:stop-shuffle-letters');
       return { ok: true };
     },

--- a/src/components/webmcp/model/tool-handlers.ts
+++ b/src/components/webmcp/model/tool-handlers.ts
@@ -1,0 +1,322 @@
+import type { WebMCPContentIndexItem } from '@/components/webmcp/lib/content-index';
+import {
+  getCodeBlockText,
+  getCurrentContentContext,
+  getPageActions,
+  getSeriesTargetHref,
+  jumpToHeading,
+} from '@/components/webmcp/lib/content-snapshot';
+
+type RouterLike = {
+  push: (href: string) => void;
+};
+
+type ThemeValue = 'light' | 'dark' | 'system';
+
+type ClipboardLike = {
+  writeText: (text: string) => Promise<void>;
+};
+
+type ToolFailure = {
+  ok: false;
+  error: string;
+};
+
+type WebMCPHandlerDeps = {
+  pathname: string;
+  router: RouterLike;
+  getTheme: () => ThemeValue;
+  setTheme: (theme: 'light' | 'dark') => void;
+  getSoundEnabled: () => boolean;
+  setSoundEnabled: (enabled: boolean) => void;
+  getCurrentHref: () => string;
+  document: Document;
+  clipboard?: ClipboardLike;
+  fetchContentIndex: () => Promise<WebMCPContentIndexItem[]>;
+  dispatchWindowEvent: (name: string, detail?: unknown) => void;
+};
+
+const destinations = {
+  home: '/',
+  article: '/article',
+  craft: '/craft',
+  'shuffle-playground': '/playground/shuffle-letters',
+} as const;
+
+function isRecord(input: unknown): input is Record<string, unknown> {
+  return typeof input === 'object' && input !== null;
+}
+
+function fail(error: string): ToolFailure {
+  return { ok: false, error };
+}
+
+function readString(input: unknown, key: string) {
+  if (!isRecord(input) || typeof input[key] !== 'string') {
+    return undefined;
+  }
+
+  return input[key];
+}
+
+function readNumber(input: unknown, key: string) {
+  if (!isRecord(input) || typeof input[key] !== 'number') {
+    return undefined;
+  }
+
+  return input[key];
+}
+
+function readBoolean(input: unknown, key: string) {
+  if (!isRecord(input) || typeof input[key] !== 'boolean') {
+    return undefined;
+  }
+
+  return input[key];
+}
+
+function isContentType(type: string): type is WebMCPContentIndexItem['type'] {
+  return type === 'article' || type === 'craft';
+}
+
+function includesText(item: WebMCPContentIndexItem, query: string) {
+  const haystack = [
+    item.title,
+    item.summary,
+    item.description,
+    item.category,
+    item.slug,
+    item.series?.name ?? '',
+  ]
+    .join(' ')
+    .toLowerCase();
+
+  return haystack.includes(query.toLowerCase());
+}
+
+export function createLazyContentIndexFetcher(fetcher: typeof fetch = fetch) {
+  let cached: Promise<WebMCPContentIndexItem[]> | undefined;
+
+  return async () => {
+    cached ??= fetcher('/api/webmcp/content-index')
+      .then(response => {
+        if (!response.ok) {
+          throw new Error('WebMCP 콘텐츠 인덱스를 불러오지 못했습니다.');
+        }
+
+        return response.json();
+      })
+      .then((body: { items?: WebMCPContentIndexItem[] }) => body.items ?? []);
+
+    return cached;
+  };
+}
+
+export function createWebMCPHandlers(deps: WebMCPHandlerDeps) {
+  return {
+    navigateSite(input: unknown) {
+      const destination = readString(input, 'destination');
+      const href = destination
+        ? destinations[destination as keyof typeof destinations]
+        : undefined;
+
+      if (!href) {
+        return fail('지원하지 않는 destination입니다.');
+      }
+
+      deps.router.push(href);
+      return { ok: true, href };
+    },
+
+    getSiteContext() {
+      return {
+        ok: true,
+        pathname: deps.pathname,
+        title: deps.document.title,
+        canonicalUrl:
+          deps.document.querySelector<HTMLLinkElement>('link[rel="canonical"]')
+            ?.href ?? deps.getCurrentHref(),
+        actions: getPageActions(deps.pathname, deps.document),
+      };
+    },
+
+    toggleTheme() {
+      const nextTheme = deps.getTheme() === 'dark' ? 'light' : 'dark';
+      deps.setTheme(nextTheme);
+      return { ok: true, theme: nextTheme };
+    },
+
+    setSound(input: unknown) {
+      const enabled = readBoolean(input, 'enabled');
+
+      if (enabled == null) {
+        return fail('enabled boolean 값이 필요합니다.');
+      }
+
+      deps.setSoundEnabled(enabled);
+      return { ok: true, enabled };
+    },
+
+    async copyCurrentUrl() {
+      const href = deps.getCurrentHref();
+
+      if (!deps.clipboard) {
+        return fail('클립보드 API를 사용할 수 없습니다.');
+      }
+
+      await deps.clipboard.writeText(href);
+      return { ok: true, href };
+    },
+
+    async findContent(input: unknown) {
+      const query = readString(input, 'query')?.trim();
+      const type = readString(input, 'type') ?? 'all';
+      const limit = readNumber(input, 'limit') ?? 5;
+
+      if (!query) {
+        return fail('query 문자열이 필요합니다.');
+      }
+
+      if (type !== 'all' && !isContentType(type)) {
+        return fail('type은 all, article, craft 중 하나여야 합니다.');
+      }
+
+      if (!Number.isInteger(limit) || limit < 1 || limit > 10) {
+        return fail('limit은 1에서 10 사이여야 합니다.');
+      }
+
+      const items = await deps.fetchContentIndex();
+      return {
+        ok: true,
+        items: items
+          .filter(item => type === 'all' || item.type === type)
+          .filter(item => includesText(item, query))
+          .slice(0, limit),
+      };
+    },
+
+    async openContent(input: unknown) {
+      const type = readString(input, 'type');
+      const slug = readString(input, 'slug');
+
+      if (!type || !isContentType(type)) {
+        return fail('type은 article 또는 craft여야 합니다.');
+      }
+
+      if (!slug) {
+        return fail('slug 문자열이 필요합니다.');
+      }
+
+      const items = await deps.fetchContentIndex();
+      const target = items.find(
+        item => item.type === type && item.slug === slug
+      );
+
+      if (!target) {
+        return fail(`${type}/${slug} 콘텐츠를 찾지 못했습니다.`);
+      }
+
+      deps.router.push(target.href);
+      return { ok: true, href: target.href };
+    },
+
+    getCurrentContentContext() {
+      return getCurrentContentContext(deps.document);
+    },
+
+    openSeries(input: unknown) {
+      const target = readString(input, 'target');
+
+      if (target !== 'series' && target !== 'previous' && target !== 'next') {
+        return fail('target은 series, previous, next 중 하나여야 합니다.');
+      }
+
+      const result = getSeriesTargetHref(target, deps.document);
+
+      if (!result.ok) {
+        return result;
+      }
+
+      deps.router.push(result.href);
+      return { ok: true, href: result.href };
+    },
+
+    jumpToHeading(input: unknown) {
+      const headingId = readString(input, 'headingId');
+
+      if (!headingId) {
+        return fail('headingId 문자열이 필요합니다.');
+      }
+
+      return jumpToHeading(headingId, deps.document);
+    },
+
+    async copyCodeBlock(input: unknown) {
+      const index = readNumber(input, 'index');
+
+      if (index == null || !Number.isInteger(index) || index < 0) {
+        return fail('index는 0 이상의 숫자여야 합니다.');
+      }
+
+      const result = getCodeBlockText(index, deps.document);
+
+      if (!result.ok) {
+        return result;
+      }
+
+      if (!deps.clipboard) {
+        return fail('클립보드 API를 사용할 수 없습니다.');
+      }
+
+      await deps.clipboard.writeText(result.text);
+      return {
+        ok: true,
+        language: result.language,
+        characterCount: result.characterCount,
+      };
+    },
+
+    listPageActions() {
+      return {
+        ok: true,
+        actions: getPageActions(deps.pathname, deps.document),
+      };
+    },
+
+    runShuffleLetters(input: unknown) {
+      const text = readString(input, 'text')?.trim();
+      const iterations = readNumber(input, 'iterations');
+      const fps = readNumber(input, 'fps');
+
+      if (!text) {
+        return fail('text 문자열이 필요합니다.');
+      }
+
+      if (
+        iterations == null ||
+        !Number.isInteger(iterations) ||
+        iterations < 1 ||
+        iterations > 50
+      ) {
+        return fail('iterations는 1에서 50 사이여야 합니다.');
+      }
+
+      if (fps == null || !Number.isInteger(fps) || fps < 1 || fps > 60) {
+        return fail('fps는 1에서 60 사이여야 합니다.');
+      }
+
+      deps.dispatchWindowEvent('webmcp:run-shuffle-letters', {
+        text,
+        iterations,
+        fps,
+      });
+
+      return { ok: true, text, iterations, fps };
+    },
+
+    stopShuffleLetters() {
+      deps.dispatchWindowEvent('webmcp:stop-shuffle-letters');
+      return { ok: true };
+    },
+  };
+}

--- a/src/components/webmcp/model/use-webmcp-tools.spec.ts
+++ b/src/components/webmcp/model/use-webmcp-tools.spec.ts
@@ -1,0 +1,14 @@
+/* eslint-disable playwright/no-standalone-expect */
+import { describe, expect, it } from 'vitest';
+
+import { getVisibleTheme } from '@/components/webmcp/model/use-webmcp-tools';
+
+describe('getVisibleTheme', () => {
+  it('reads the visible theme from the live html class', () => {
+    document.documentElement.classList.remove('dark');
+    expect(getVisibleTheme(document)).toBe('light');
+
+    document.documentElement.classList.add('dark');
+    expect(getVisibleTheme(document)).toBe('dark');
+  });
+});

--- a/src/components/webmcp/model/use-webmcp-tools.ts
+++ b/src/components/webmcp/model/use-webmcp-tools.ts
@@ -1,0 +1,158 @@
+'use client';
+
+import { useTheme } from 'next-themes';
+import type { Route } from 'next';
+import { usePathname, useRouter } from 'next/navigation';
+import { useMemo } from 'react';
+
+import { useSoundStore } from '@/components/sound';
+import {
+  createToolDescriptor,
+  emptyObjectSchema,
+  webMCPSchemas,
+} from '@/components/webmcp/lib/schemas';
+import {
+  createLazyContentIndexFetcher,
+  createWebMCPHandlers,
+} from '@/components/webmcp/model/tool-handlers';
+
+const fetchContentIndex = createLazyContentIndexFetcher();
+
+export function useWebMCPTools() {
+  const pathname = usePathname();
+  const router = useRouter();
+  const { resolvedTheme, setTheme } = useTheme();
+  const isSoundEnabled = useSoundStore(state => state.isSoundEnabled);
+  const setSoundEnabled = useSoundStore(state => state.setSoundEnabled);
+
+  return useMemo(() => {
+    const handlers = createWebMCPHandlers({
+      pathname,
+      router: {
+        push: href => {
+          router.push(href as Route);
+        },
+      },
+      getTheme: () => (resolvedTheme === 'dark' ? 'dark' : 'light'),
+      setTheme,
+      getSoundEnabled: () => isSoundEnabled,
+      setSoundEnabled,
+      getCurrentHref: () => window.location.href,
+      document,
+      clipboard: navigator.clipboard,
+      fetchContentIndex,
+      dispatchWindowEvent: (name, detail) => {
+        window.dispatchEvent(new CustomEvent(name, { detail }));
+      },
+    });
+
+    const tools = [
+      createToolDescriptor({
+        name: 'navigate_site',
+        description: 'Navigate to a safe internal page on bendd.me.',
+        inputSchema: webMCPSchemas.navigateSite,
+        execute: handlers.navigateSite,
+      }),
+      createToolDescriptor({
+        name: 'get_site_context',
+        description:
+          'Read the current bendd.me route, title, canonical URL, and available actions.',
+        inputSchema: emptyObjectSchema,
+        annotations: { readOnlyHint: true },
+        execute: handlers.getSiteContext,
+      }),
+      createToolDescriptor({
+        name: 'toggle_theme',
+        description: 'Toggle the visible site theme between light and dark.',
+        inputSchema: emptyObjectSchema,
+        execute: handlers.toggleTheme,
+      }),
+      createToolDescriptor({
+        name: 'set_sound',
+        description: 'Enable or disable site interaction sounds.',
+        inputSchema: webMCPSchemas.setSound,
+        execute: handlers.setSound,
+      }),
+      createToolDescriptor({
+        name: 'copy_current_url',
+        description: 'Copy the current page URL to the clipboard.',
+        inputSchema: emptyObjectSchema,
+        execute: handlers.copyCurrentUrl,
+      }),
+      createToolDescriptor({
+        name: 'find_content',
+        description:
+          'Search bendd.me article and craft metadata by title, summary, description, category, slug, or series.',
+        inputSchema: webMCPSchemas.findContent,
+        annotations: { readOnlyHint: true },
+        execute: handlers.findContent,
+      }),
+      createToolDescriptor({
+        name: 'open_content',
+        description: 'Open an internal article or craft page by type and slug.',
+        inputSchema: webMCPSchemas.openContent,
+        execute: handlers.openContent,
+      }),
+      createToolDescriptor({
+        name: 'get_current_content_context',
+        description:
+          'Read the current article or craft title, metadata, TL;DR, headings, and a short excerpt.',
+        inputSchema: emptyObjectSchema,
+        annotations: { readOnlyHint: true },
+        execute: handlers.getCurrentContentContext,
+      }),
+      createToolDescriptor({
+        name: 'open_series',
+        description:
+          'Open the current series page, previous article, or next article when available.',
+        inputSchema: webMCPSchemas.openSeries,
+        execute: handlers.openSeries,
+      }),
+      createToolDescriptor({
+        name: 'jump_to_heading',
+        description:
+          'Scroll the current article or craft page to a heading by id.',
+        inputSchema: webMCPSchemas.jumpToHeading,
+        execute: handlers.jumpToHeading,
+      }),
+      createToolDescriptor({
+        name: 'copy_code_block',
+        description: 'Copy a visible MDX code block by zero-based index.',
+        inputSchema: webMCPSchemas.copyCodeBlock,
+        execute: handlers.copyCodeBlock,
+      }),
+      createToolDescriptor({
+        name: 'list_page_actions',
+        description:
+          'List the WebMCP actions that are meaningful on the current route.',
+        inputSchema: emptyObjectSchema,
+        annotations: { readOnlyHint: true },
+        execute: handlers.listPageActions,
+      }),
+      createToolDescriptor({
+        name: 'run_shuffle_letters',
+        description:
+          'Fill and run the shuffle letters playground with visible values.',
+        inputSchema: webMCPSchemas.runShuffleLetters,
+        execute: handlers.runShuffleLetters,
+      }),
+      createToolDescriptor({
+        name: 'stop_shuffle_letters',
+        description: 'Stop the running shuffle letters animation.',
+        inputSchema: emptyObjectSchema,
+        execute: handlers.stopShuffleLetters,
+      }),
+    ];
+
+    const available = new Set<string>(handlers.listPageActions().actions);
+
+    return tools.filter(tool => available.has(tool.name));
+  }, [
+    isSoundEnabled,
+    pathname,
+    resolvedTheme,
+    router,
+    setSoundEnabled,
+    setTheme,
+  ]);
+}

--- a/src/components/webmcp/model/use-webmcp-tools.ts
+++ b/src/components/webmcp/model/use-webmcp-tools.ts
@@ -3,7 +3,7 @@
 import { useTheme } from 'next-themes';
 import type { Route } from 'next';
 import { usePathname, useRouter } from 'next/navigation';
-import { useMemo } from 'react';
+import { useCallback } from 'react';
 
 import { useSoundStore } from '@/components/sound';
 import {
@@ -15,6 +15,7 @@ import {
   createLazyContentIndexFetcher,
   createWebMCPHandlers,
 } from '@/components/webmcp/model/tool-handlers';
+import type { AnyWebMCPToolDescriptor } from '@/components/webmcp/types/webmcp';
 
 const fetchContentIndex = createLazyContentIndexFetcher();
 
@@ -25,7 +26,7 @@ export function useWebMCPTools() {
   const isSoundEnabled = useSoundStore(state => state.isSoundEnabled);
   const setSoundEnabled = useSoundStore(state => state.setSoundEnabled);
 
-  return useMemo(() => {
+  return useCallback((): AnyWebMCPToolDescriptor[] => {
     const handlers = createWebMCPHandlers({
       pathname,
       router: {

--- a/src/components/webmcp/model/use-webmcp-tools.ts
+++ b/src/components/webmcp/model/use-webmcp-tools.ts
@@ -19,6 +19,10 @@ import type { AnyWebMCPToolDescriptor } from '@/components/webmcp/types/webmcp';
 
 const fetchContentIndex = createLazyContentIndexFetcher();
 
+export function getVisibleTheme(doc: Document = document) {
+  return doc.documentElement.classList.contains('dark') ? 'dark' : 'light';
+}
+
 export function useWebMCPTools() {
   const pathname = usePathname();
   const router = useRouter();
@@ -34,7 +38,7 @@ export function useWebMCPTools() {
           router.push(href as Route);
         },
       },
-      getTheme: () => (resolvedTheme === 'dark' ? 'dark' : 'light'),
+      getTheme: () => getVisibleTheme(document),
       setTheme,
       getSoundEnabled: () => isSoundEnabled,
       setSoundEnabled,

--- a/src/components/webmcp/types/webmcp.d.ts
+++ b/src/components/webmcp/types/webmcp.d.ts
@@ -10,6 +10,7 @@ export type WebMCPJSONSchema = {
   minimum?: number;
   maximum?: number;
   anyOf?: readonly WebMCPJSONSchema[];
+  oneOf?: readonly WebMCPJSONSchema[];
 };
 
 export type WebMCPToolAnnotations = {
@@ -17,6 +18,7 @@ export type WebMCPToolAnnotations = {
   destructiveHint?: boolean;
   idempotentHint?: boolean;
   openWorldHint?: boolean;
+  untrustedContentHint?: boolean;
 };
 
 export type WebMCPToolDescriptor<Input = unknown, Output = unknown> = {
@@ -29,6 +31,7 @@ export type WebMCPToolDescriptor<Input = unknown, Output = unknown> = {
 
 export type WebMCPRegisterOptions = {
   signal?: AbortSignal;
+  exposedTo?: readonly string[];
 };
 
 export type WebMCPModelContext = {
@@ -52,6 +55,7 @@ declare module 'react' {
   }
 
   interface HTMLAttributes<T> {
+    toolparamtitle?: string;
     toolparamdescription?: string;
   }
 }

--- a/src/components/webmcp/types/webmcp.d.ts
+++ b/src/components/webmcp/types/webmcp.d.ts
@@ -37,6 +37,16 @@ export type WebMCPToolDescriptor<Input = unknown, Output = unknown> = {
   ) => Output | Promise<Output>;
 };
 
+export type AnyWebMCPToolDescriptor = Omit<
+  WebMCPToolDescriptor<never, unknown>,
+  'execute'
+> & {
+  execute: (
+    input: never,
+    client: WebMCPModelContextClient
+  ) => unknown | Promise<unknown>;
+};
+
 export type WebMCPRegisterOptions = {
   signal?: AbortSignal;
   exposedTo?: readonly string[];
@@ -44,7 +54,7 @@ export type WebMCPRegisterOptions = {
 
 export type WebMCPModelContext = {
   registerTool: (
-    tool: WebMCPToolDescriptor,
+    tool: AnyWebMCPToolDescriptor,
     options?: WebMCPRegisterOptions
   ) => void;
 };

--- a/src/components/webmcp/types/webmcp.d.ts
+++ b/src/components/webmcp/types/webmcp.d.ts
@@ -1,0 +1,57 @@
+export type WebMCPJSONSchema = {
+  type: string;
+  properties?: Record<string, WebMCPJSONSchema>;
+  required?: string[];
+  additionalProperties?: boolean;
+  enum?: readonly string[];
+  const?: string | number | boolean;
+  title?: string;
+  description?: string;
+  minimum?: number;
+  maximum?: number;
+  anyOf?: readonly WebMCPJSONSchema[];
+};
+
+export type WebMCPToolAnnotations = {
+  readOnlyHint?: boolean;
+  destructiveHint?: boolean;
+  idempotentHint?: boolean;
+  openWorldHint?: boolean;
+};
+
+export type WebMCPToolDescriptor<Input = unknown, Output = unknown> = {
+  name: string;
+  description: string;
+  inputSchema: WebMCPJSONSchema;
+  annotations?: WebMCPToolAnnotations;
+  execute: (input: Input) => Output | Promise<Output>;
+};
+
+export type WebMCPRegisterOptions = {
+  signal?: AbortSignal;
+};
+
+export type WebMCPModelContext = {
+  registerTool: (
+    tool: WebMCPToolDescriptor,
+    options?: WebMCPRegisterOptions
+  ) => void;
+};
+
+declare global {
+  interface Navigator {
+    modelContext?: WebMCPModelContext;
+  }
+}
+
+declare module 'react' {
+  interface FormHTMLAttributes<T> {
+    toolname?: string;
+    tooldescription?: string;
+    toolautosubmit?: boolean | '';
+  }
+
+  interface HTMLAttributes<T> {
+    toolparamdescription?: string;
+  }
+}

--- a/src/components/webmcp/types/webmcp.d.ts
+++ b/src/components/webmcp/types/webmcp.d.ts
@@ -21,12 +21,20 @@ export type WebMCPToolAnnotations = {
   untrustedContentHint?: boolean;
 };
 
+export type WebMCPModelContextClient = {
+  requestUserInteraction?: (options?: { message?: string }) => Promise<void>;
+};
+
 export type WebMCPToolDescriptor<Input = unknown, Output = unknown> = {
   name: string;
+  title?: string;
   description: string;
   inputSchema: WebMCPJSONSchema;
   annotations?: WebMCPToolAnnotations;
-  execute: (input: Input) => Output | Promise<Output>;
+  execute: (
+    input: Input,
+    client: WebMCPModelContextClient
+  ) => Output | Promise<Output>;
 };
 
 export type WebMCPRegisterOptions = {

--- a/src/components/webmcp/ui/webmcp-provider.spec.tsx
+++ b/src/components/webmcp/ui/webmcp-provider.spec.tsx
@@ -1,22 +1,30 @@
 import { render } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
+import type { AnyWebMCPToolDescriptor } from '@/components/webmcp/types/webmcp';
+
+const mocks = vi.hoisted(() => ({
+  buildTools: vi.fn((): AnyWebMCPToolDescriptor[] => []),
+}));
+
 vi.mock('@/components/webmcp/model/use-webmcp-tools', () => ({
-  useWebMCPTools: () => [
-    {
-      name: 'get_site_context',
-      description: 'Read site context.',
-      inputSchema: {
-        type: 'object',
-        properties: {},
-        additionalProperties: false,
-      },
-      execute: vi.fn(),
-    },
-  ],
+  useWebMCPTools: () => mocks.buildTools,
 }));
 
 import { WebMCPProvider } from '@/components/webmcp/ui/webmcp-provider';
+
+function createDescriptor(name: string): AnyWebMCPToolDescriptor {
+  return {
+    name,
+    description: `Register ${name}.`,
+    inputSchema: {
+      type: 'object',
+      properties: {},
+      additionalProperties: false,
+    },
+    execute: vi.fn(),
+  };
+}
 
 describe('WebMCPProvider', () => {
   let originalNavigatorDescriptor: PropertyDescriptor | undefined;
@@ -30,6 +38,7 @@ describe('WebMCPProvider', () => {
     );
     originalRequestIdleCallback = globalThis.requestIdleCallback;
     originalCancelIdleCallback = globalThis.cancelIdleCallback;
+    mocks.buildTools.mockReturnValue([createDescriptor('get_site_context')]);
   });
 
   afterEach(() => {
@@ -43,6 +52,8 @@ describe('WebMCPProvider', () => {
 
     globalThis.requestIdleCallback = originalRequestIdleCallback;
     globalThis.cancelIdleCallback = originalCancelIdleCallback;
+    document.body.innerHTML = '';
+    document.body.removeAttribute('data-committed-route');
     vi.clearAllMocks();
   });
 
@@ -107,5 +118,34 @@ describe('WebMCPProvider', () => {
 
     expect(globalThis.cancelIdleCallback).toHaveBeenCalledWith(123);
     expect(registerTool).not.toHaveBeenCalled();
+  });
+
+  it('builds route-filtered tools during idle after the committed DOM is current', () => {
+    const registerTool = vi.fn();
+    const idleCallbacks: IdleRequestCallback[] = [];
+    globalThis.requestIdleCallback = vi.fn((callback: IdleRequestCallback) => {
+      idleCallbacks.push(callback);
+      return idleCallbacks.length;
+    }) as typeof requestIdleCallback;
+    Object.defineProperty(globalThis, 'navigator', {
+      configurable: true,
+      value: {
+        modelContext: { registerTool },
+      },
+    });
+    document.body.dataset.committedRoute = 'previous';
+    mocks.buildTools.mockImplementation(() => [
+      createDescriptor(
+        `${document.body.dataset.committedRoute ?? 'missing'}_tool`
+      ),
+    ]);
+
+    render(<WebMCPProvider />);
+
+    document.body.dataset.committedRoute = 'current';
+    idleCallbacks[0]({} as IdleDeadline);
+
+    expect(registerTool).toHaveBeenCalledTimes(1);
+    expect(registerTool.mock.calls[0][0].name).toBe('current_tool');
   });
 });

--- a/src/components/webmcp/ui/webmcp-provider.spec.tsx
+++ b/src/components/webmcp/ui/webmcp-provider.spec.tsx
@@ -1,0 +1,111 @@
+import { render } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('@/components/webmcp/model/use-webmcp-tools', () => ({
+  useWebMCPTools: () => [
+    {
+      name: 'get_site_context',
+      description: 'Read site context.',
+      inputSchema: {
+        type: 'object',
+        properties: {},
+        additionalProperties: false,
+      },
+      execute: vi.fn(),
+    },
+  ],
+}));
+
+import { WebMCPProvider } from '@/components/webmcp/ui/webmcp-provider';
+
+describe('WebMCPProvider', () => {
+  let originalNavigatorDescriptor: PropertyDescriptor | undefined;
+  let originalRequestIdleCallback: typeof globalThis.requestIdleCallback;
+  let originalCancelIdleCallback: typeof globalThis.cancelIdleCallback;
+
+  beforeEach(() => {
+    originalNavigatorDescriptor = Object.getOwnPropertyDescriptor(
+      globalThis,
+      'navigator'
+    );
+    originalRequestIdleCallback = globalThis.requestIdleCallback;
+    originalCancelIdleCallback = globalThis.cancelIdleCallback;
+  });
+
+  afterEach(() => {
+    if (originalNavigatorDescriptor) {
+      Object.defineProperty(
+        globalThis,
+        'navigator',
+        originalNavigatorDescriptor
+      );
+    }
+
+    globalThis.requestIdleCallback = originalRequestIdleCallback;
+    globalThis.cancelIdleCallback = originalCancelIdleCallback;
+    vi.clearAllMocks();
+  });
+
+  it('does not schedule idle work when WebMCP is unsupported', () => {
+    const idle = vi.fn();
+    globalThis.requestIdleCallback = idle as typeof requestIdleCallback;
+    Object.defineProperty(globalThis, 'navigator', {
+      configurable: true,
+      value: {},
+    });
+
+    render(<WebMCPProvider />);
+
+    expect(idle).not.toHaveBeenCalled();
+  });
+
+  it('registers tools during idle time and aborts on unmount', () => {
+    const registerTool = vi.fn();
+    const idleCallbacks: IdleRequestCallback[] = [];
+    globalThis.requestIdleCallback = vi.fn((callback: IdleRequestCallback) => {
+      idleCallbacks.push(callback);
+      return idleCallbacks.length;
+    }) as typeof requestIdleCallback;
+    globalThis.cancelIdleCallback = vi.fn() as typeof cancelIdleCallback;
+    Object.defineProperty(globalThis, 'navigator', {
+      configurable: true,
+      value: {
+        modelContext: { registerTool },
+      },
+    });
+
+    const { unmount } = render(<WebMCPProvider />);
+
+    expect(registerTool).not.toHaveBeenCalled();
+    idleCallbacks[0]({} as IdleDeadline);
+    expect(registerTool).toHaveBeenCalledTimes(1);
+
+    const signal = registerTool.mock.calls[0][1].signal as AbortSignal;
+    expect(signal.aborted).toBe(false);
+
+    unmount();
+
+    expect(signal.aborted).toBe(true);
+  });
+
+  it('cancels pending idle registration before the callback runs', () => {
+    const registerTool = vi.fn();
+    globalThis.requestIdleCallback = vi.fn(
+      () => 123
+    ) as typeof requestIdleCallback;
+    globalThis.cancelIdleCallback = vi.fn() as typeof cancelIdleCallback;
+    Object.defineProperty(globalThis, 'navigator', {
+      configurable: true,
+      value: {
+        modelContext: { registerTool },
+      },
+    });
+
+    const { unmount } = render(<WebMCPProvider />);
+
+    unmount();
+
+    expect(globalThis.cancelIdleCallback).toHaveBeenCalledWith(123);
+    expect(registerTool).not.toHaveBeenCalled();
+  });
+});

--- a/src/components/webmcp/ui/webmcp-provider.spec.tsx
+++ b/src/components/webmcp/ui/webmcp-provider.spec.tsx
@@ -182,4 +182,29 @@ describe('WebMCPProvider', () => {
     expect(registerTool).toHaveBeenCalledTimes(1);
     expect(registerTool.mock.calls[0][0].name).toBe('stop_shuffle_letters');
   });
+
+  it('keeps cleanup safe when tool registration throws during idle', () => {
+    const registerTool = vi.fn(() => {
+      throw new Error('Registration failed');
+    });
+    const idleCallbacks: IdleRequestCallback[] = [];
+    globalThis.requestIdleCallback = vi.fn((callback: IdleRequestCallback) => {
+      idleCallbacks.push(callback);
+      return idleCallbacks.length;
+    }) as typeof requestIdleCallback;
+    globalThis.cancelIdleCallback = vi.fn() as typeof cancelIdleCallback;
+    Object.defineProperty(globalThis, 'navigator', {
+      configurable: true,
+      value: {
+        modelContext: { registerTool },
+      },
+    });
+    mocks.buildTools.mockReturnValue([createDescriptor('get_site_context')]);
+
+    const { unmount } = render(<WebMCPProvider />);
+
+    expect(() => idleCallbacks[0]({} as IdleDeadline)).not.toThrow();
+    expect(registerTool).toHaveBeenCalledTimes(1);
+    expect(() => unmount()).not.toThrow();
+  });
 });

--- a/src/components/webmcp/ui/webmcp-provider.spec.tsx
+++ b/src/components/webmcp/ui/webmcp-provider.spec.tsx
@@ -148,4 +148,38 @@ describe('WebMCPProvider', () => {
     expect(registerTool).toHaveBeenCalledTimes(1);
     expect(registerTool.mock.calls[0][0].name).toBe('current_tool');
   });
+
+  it('skips imperative tools already exposed by declarative forms', () => {
+    const registerTool = vi.fn(tool => {
+      if (tool.name === 'run_shuffle_letters') {
+        throw new Error('Duplicate tool name');
+      }
+    });
+    const idleCallbacks: IdleRequestCallback[] = [];
+    globalThis.requestIdleCallback = vi.fn((callback: IdleRequestCallback) => {
+      idleCallbacks.push(callback);
+      return idleCallbacks.length;
+    }) as typeof requestIdleCallback;
+    Object.defineProperty(globalThis, 'navigator', {
+      configurable: true,
+      value: {
+        modelContext: { registerTool },
+      },
+    });
+    document.body.innerHTML = `
+      <form toolname="run_shuffle_letters">
+        <button type="submit">Run</button>
+      </form>
+    `;
+    mocks.buildTools.mockReturnValue([
+      createDescriptor('run_shuffle_letters'),
+      createDescriptor('stop_shuffle_letters'),
+    ]);
+
+    render(<WebMCPProvider />);
+
+    expect(() => idleCallbacks[0]({} as IdleDeadline)).not.toThrow();
+    expect(registerTool).toHaveBeenCalledTimes(1);
+    expect(registerTool.mock.calls[0][0].name).toBe('stop_shuffle_letters');
+  });
 });

--- a/src/components/webmcp/ui/webmcp-provider.tsx
+++ b/src/components/webmcp/ui/webmcp-provider.tsx
@@ -37,11 +37,15 @@ export function WebMCPProvider() {
     const cancelIdle = globalThis.cancelIdleCallback ?? window.clearTimeout;
 
     const idleId = requestIdle(() => {
-      const declarativeToolNames = getDeclarativeToolNames(document);
-      const tools = buildTools().filter(
-        tool => !declarativeToolNames.has(tool.name)
-      );
-      cleanup = registerWebMCPTools(tools);
+      try {
+        const declarativeToolNames = getDeclarativeToolNames(document);
+        const tools = buildTools().filter(
+          tool => !declarativeToolNames.has(tool.name)
+        );
+        cleanup = registerWebMCPTools(tools);
+      } catch {
+        cleanup = () => {};
+      }
     });
 
     return () => {

--- a/src/components/webmcp/ui/webmcp-provider.tsx
+++ b/src/components/webmcp/ui/webmcp-provider.tsx
@@ -17,7 +17,7 @@ const requestIdleFallback = (callback: IdleRequestCallback) =>
   }, 0);
 
 export function WebMCPProvider() {
-  const tools = useWebMCPTools();
+  const buildTools = useWebMCPTools();
 
   useEffect(() => {
     if (!hasModelContext()) {
@@ -29,6 +29,7 @@ export function WebMCPProvider() {
     const cancelIdle = globalThis.cancelIdleCallback ?? window.clearTimeout;
 
     const idleId = requestIdle(() => {
+      const tools = buildTools();
       cleanup = registerWebMCPTools(tools);
     });
 
@@ -36,7 +37,7 @@ export function WebMCPProvider() {
       cancelIdle(idleId);
       cleanup();
     };
-  }, [tools]);
+  }, [buildTools]);
 
   return null;
 }

--- a/src/components/webmcp/ui/webmcp-provider.tsx
+++ b/src/components/webmcp/ui/webmcp-provider.tsx
@@ -1,0 +1,42 @@
+'use client';
+
+import { useEffect } from 'react';
+
+import {
+  hasModelContext,
+  registerWebMCPTools,
+} from '@/components/webmcp/lib/register-tool';
+import { useWebMCPTools } from '@/components/webmcp/model/use-webmcp-tools';
+
+const requestIdleFallback = (callback: IdleRequestCallback) =>
+  window.setTimeout(() => {
+    callback({
+      didTimeout: false,
+      timeRemaining: () => 0,
+    });
+  }, 0);
+
+export function WebMCPProvider() {
+  const tools = useWebMCPTools();
+
+  useEffect(() => {
+    if (!hasModelContext()) {
+      return;
+    }
+
+    let cleanup = () => {};
+    const requestIdle = globalThis.requestIdleCallback ?? requestIdleFallback;
+    const cancelIdle = globalThis.cancelIdleCallback ?? window.clearTimeout;
+
+    const idleId = requestIdle(() => {
+      cleanup = registerWebMCPTools(tools);
+    });
+
+    return () => {
+      cancelIdle(idleId);
+      cleanup();
+    };
+  }, [tools]);
+
+  return null;
+}

--- a/src/components/webmcp/ui/webmcp-provider.tsx
+++ b/src/components/webmcp/ui/webmcp-provider.tsx
@@ -16,6 +16,14 @@ const requestIdleFallback = (callback: IdleRequestCallback) =>
     });
   }, 0);
 
+function getDeclarativeToolNames(doc: Document) {
+  return new Set(
+    [...doc.querySelectorAll<HTMLFormElement>('form[toolname]')]
+      .map(form => form.getAttribute('toolname'))
+      .filter((name): name is string => Boolean(name))
+  );
+}
+
 export function WebMCPProvider() {
   const buildTools = useWebMCPTools();
 
@@ -29,7 +37,10 @@ export function WebMCPProvider() {
     const cancelIdle = globalThis.cancelIdleCallback ?? window.clearTimeout;
 
     const idleId = requestIdle(() => {
-      const tools = buildTools();
+      const declarativeToolNames = getDeclarativeToolNames(document);
+      const tools = buildTools().filter(
+        tool => !declarativeToolNames.has(tool.name)
+      );
       cleanup = registerWebMCPTools(tools);
     });
 

--- a/src/globals.css
+++ b/src/globals.css
@@ -114,6 +114,16 @@
     @apply font-bold no-underline;
   }
 
+  form:tool-form-active {
+    outline: hsl(var(--ring)) dashed 1px;
+    outline-offset: 4px;
+  }
+
+  button:tool-submit-active {
+    outline: hsl(var(--primary)) dashed 1px;
+    outline-offset: 2px;
+  }
+
   .browser-icon {
     display: inline-block;
     width: 14px;

--- a/src/mdx/components/pre/pre.tsx
+++ b/src/mdx/components/pre/pre.tsx
@@ -12,6 +12,7 @@ export function MDXPre({ children, ...props }: HTMLAttributes<HTMLPreElement>) {
     <div className="relative">
       <pre
         ref={preRef}
+        data-webmcp-code-block
         className={cn(
           'my-0 overflow-x-auto rounded-lg border border-solid border-border px-0 py-3',
           'contrast-more:border-current contrast-more:dark:border-current'

--- a/src/mdx/components/shuffle-letters-demo/shuffle-letters-demo.spec.tsx
+++ b/src/mdx/components/shuffle-letters-demo/shuffle-letters-demo.spec.tsx
@@ -1,0 +1,114 @@
+import { act, render, screen } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const shuffleMocks = vi.hoisted(() => {
+  const stopAnimation = vi.fn();
+  return {
+    stopAnimation,
+    shuffleLetters: vi.fn(() => stopAnimation),
+  };
+});
+
+vi.mock('@/components/article/lib/shuffle-letters', () => ({
+  shuffleLetters: shuffleMocks.shuffleLetters,
+}));
+
+import { shuffleLetters } from '@/components/article/lib/shuffle-letters';
+import { MDXShuffleLettersDemo } from '@/mdx/components/shuffle-letters-demo/shuffle-letters-demo';
+
+function renderShuffleLettersDemo() {
+  return render(
+    <MDXShuffleLettersDemo
+      initialText="한글 English 123 @#$%"
+      initialIterations={15}
+      initialFps={40}
+    />
+  );
+}
+
+describe('MDXShuffleLettersDemo WebMCP integration', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('exposes declarative WebMCP form annotations', () => {
+    renderShuffleLettersDemo();
+
+    const form = screen.getByRole('form', {
+      name: 'Shuffle letters playground',
+    });
+
+    expect(form.getAttribute('toolname')).toBe('run_shuffle_letters');
+    expect(form.hasAttribute('toolautosubmit')).toBe(true);
+    expect(form.getAttribute('tooldescription')).toBe(
+      'Runs the shuffle letters animation with visible form values.'
+    );
+    expect(screen.getByLabelText('텍스트').getAttribute('name')).toBe('text');
+    expect(
+      screen.getByLabelText('텍스트').getAttribute('toolparamdescription')
+    ).toBe('Text to animate with the shuffle letters effect.');
+    expect(
+      screen.getByLabelText('iterations (1-50)').getAttribute('name')
+    ).toBe('iterations');
+    expect(
+      screen
+        .getByLabelText('iterations (1-50)')
+        .getAttribute('toolparamdescription')
+    ).toBe(
+      'Number of random character replacements per letter. Use 1 through 50.'
+    );
+    expect(screen.getByLabelText('fps (1-60)').getAttribute('name')).toBe(
+      'fps'
+    );
+    expect(
+      screen.getByLabelText('fps (1-60)').getAttribute('toolparamdescription')
+    ).toBe('Animation frames per second. Use 1 through 60.');
+  });
+
+  it('runs visible animation when the WebMCP custom event is dispatched', () => {
+    renderShuffleLettersDemo();
+
+    act(() => {
+      window.dispatchEvent(
+        new CustomEvent('webmcp:run-shuffle-letters', {
+          detail: {
+            text: 'Agent text',
+            iterations: 9,
+            fps: 24,
+          },
+        })
+      );
+    });
+
+    expect(screen.getByDisplayValue('Agent text')).toBeDefined();
+    expect(shuffleLetters).toHaveBeenCalledWith(
+      expect.any(HTMLDivElement),
+      expect.objectContaining({
+        iterations: 9,
+        fps: 24,
+      })
+    );
+  });
+
+  it('stops animation when the WebMCP stop event is dispatched', () => {
+    renderShuffleLettersDemo();
+
+    act(() => {
+      window.dispatchEvent(
+        new CustomEvent('webmcp:run-shuffle-letters', {
+          detail: {
+            text: 'Stop me',
+            iterations: 4,
+            fps: 12,
+          },
+        })
+      );
+    });
+
+    act(() => {
+      window.dispatchEvent(new CustomEvent('webmcp:stop-shuffle-letters'));
+    });
+
+    expect(shuffleMocks.stopAnimation).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/mdx/components/shuffle-letters-demo/shuffle-letters-demo.spec.tsx
+++ b/src/mdx/components/shuffle-letters-demo/shuffle-letters-demo.spec.tsx
@@ -1,4 +1,4 @@
-import { act, render, screen } from '@testing-library/react';
+import { act, fireEvent, render, screen } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 const shuffleMocks = vi.hoisted(() => {
@@ -24,6 +24,32 @@ function renderShuffleLettersDemo() {
       initialFps={40}
     />
   );
+}
+
+function submitFormAsAgent() {
+  const form = screen.getByRole('form', {
+    name: 'Shuffle letters playground',
+  });
+  const respondWith = vi.fn();
+  const event = new Event('submit', {
+    bubbles: true,
+    cancelable: true,
+  });
+
+  Object.defineProperties(event, {
+    agentInvoked: {
+      value: true,
+    },
+    respondWith: {
+      value: respondWith,
+    },
+  });
+
+  act(() => {
+    form.dispatchEvent(event);
+  });
+
+  return respondWith;
 }
 
 describe('MDXShuffleLettersDemo WebMCP integration', () => {
@@ -87,6 +113,58 @@ describe('MDXShuffleLettersDemo WebMCP integration', () => {
         iterations: 9,
         fps: 24,
       })
+    );
+  });
+
+  it('responds with sanitized values when an agent submits the form', async () => {
+    renderShuffleLettersDemo();
+
+    fireEvent.change(screen.getByLabelText('텍스트'), {
+      target: { value: 'Agent submit text' },
+    });
+    fireEvent.change(screen.getByLabelText('iterations (1-50)'), {
+      target: { value: '9' },
+    });
+    fireEvent.change(screen.getByLabelText('fps (1-60)'), {
+      target: { value: '24' },
+    });
+
+    const respondWith = submitFormAsAgent();
+
+    expect(respondWith).toHaveBeenCalledTimes(1);
+    await expect(respondWith.mock.calls[0][0]).resolves.toEqual({
+      ok: true,
+      text: 'Agent submit text',
+      iterations: 9,
+      fps: 24,
+    });
+    expect(screen.getByDisplayValue('Agent submit text')).toBeDefined();
+    expect(shuffleLetters).toHaveBeenCalledWith(
+      expect.any(HTMLDivElement),
+      expect.objectContaining({
+        iterations: 9,
+        fps: 24,
+      })
+    );
+  });
+
+  it('responds with a failure and does not animate invalid agent submits', async () => {
+    renderShuffleLettersDemo();
+
+    fireEvent.change(screen.getByLabelText('텍스트'), {
+      target: { value: '   ' },
+    });
+
+    const respondWith = submitFormAsAgent();
+
+    expect(respondWith).toHaveBeenCalledTimes(1);
+    await expect(respondWith.mock.calls[0][0]).resolves.toEqual({
+      ok: false,
+      error: 'text, iterations, fps 값이 올바르지 않습니다.',
+    });
+    expect(shuffleLetters).not.toHaveBeenCalled();
+    expect((screen.getByLabelText('텍스트') as HTMLInputElement).value).toBe(
+      '   '
     );
   });
 

--- a/src/mdx/components/shuffle-letters-demo/shuffle-letters-demo.spec.tsx
+++ b/src/mdx/components/shuffle-letters-demo/shuffle-letters-demo.spec.tsx
@@ -111,4 +111,74 @@ describe('MDXShuffleLettersDemo WebMCP integration', () => {
 
     expect(shuffleMocks.stopAnimation).toHaveBeenCalledTimes(1);
   });
+
+  it('ignores duplicate run events while an animation is active', () => {
+    renderShuffleLettersDemo();
+
+    act(() => {
+      window.dispatchEvent(
+        new CustomEvent('webmcp:run-shuffle-letters', {
+          detail: {
+            text: 'First run',
+            iterations: 4,
+            fps: 12,
+          },
+        })
+      );
+      window.dispatchEvent(
+        new CustomEvent('webmcp:run-shuffle-letters', {
+          detail: {
+            text: 'Second run',
+            iterations: 5,
+            fps: 20,
+          },
+        })
+      );
+    });
+
+    expect(shuffleLetters).toHaveBeenCalledTimes(1);
+    expect(screen.getByDisplayValue('First run')).toBeDefined();
+  });
+
+  it.each([
+    ['missing detail', undefined],
+    ['empty text', { text: '   ', iterations: 4, fps: 12 }],
+    ['low iterations', { text: 'Invalid', iterations: 0, fps: 12 }],
+    ['high fps', { text: 'Invalid', iterations: 4, fps: 61 }],
+    ['NaN iterations', { text: 'Invalid', iterations: Number.NaN, fps: 12 }],
+    ['wrong text type', { text: 123, iterations: 4, fps: 12 }],
+    ['wrong iterations type', { text: 'Invalid', iterations: '4', fps: 12 }],
+    ['wrong fps type', { text: 'Invalid', iterations: 4, fps: '12' }],
+  ])('ignores invalid WebMCP run payloads: %s', (_caseName, detail) => {
+    renderShuffleLettersDemo();
+
+    act(() => {
+      window.dispatchEvent(
+        new CustomEvent('webmcp:run-shuffle-letters', {
+          detail,
+        })
+      );
+    });
+
+    expect(shuffleLetters).not.toHaveBeenCalled();
+  });
+
+  it('keeps agent text visible when run and stop are dispatched together', () => {
+    renderShuffleLettersDemo();
+
+    act(() => {
+      window.dispatchEvent(
+        new CustomEvent('webmcp:run-shuffle-letters', {
+          detail: {
+            text: 'Agent text survives stop',
+            iterations: 4,
+            fps: 12,
+          },
+        })
+      );
+      window.dispatchEvent(new CustomEvent('webmcp:stop-shuffle-letters'));
+    });
+
+    expect(screen.getByText('Agent text survives stop')).toBeDefined();
+  });
 });

--- a/src/mdx/components/shuffle-letters-demo/shuffle-letters-demo.tsx
+++ b/src/mdx/components/shuffle-letters-demo/shuffle-letters-demo.tsx
@@ -3,10 +3,9 @@
 import { shuffleLetters } from '@/components/article/lib/shuffle-letters';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
+import { createMDXComponent } from '@/mdx/common/create-mdx-component';
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { z } from 'zod';
-
-import { createMDXComponent } from '../../common/create-mdx-component';
 
 const ShuffleLettersDemoSchema = z.object({
   initialText: z.string().optional().default('한글 English 123 @#$%'),

--- a/src/mdx/components/shuffle-letters-demo/shuffle-letters-demo.tsx
+++ b/src/mdx/components/shuffle-letters-demo/shuffle-letters-demo.tsx
@@ -26,6 +26,11 @@ type AgentSubmitEvent = SubmitEvent & {
   respondWith?: (promise: Promise<unknown>) => void;
 };
 
+const invalidPayloadResponse = {
+  ok: false,
+  error: 'text, iterations, fps 값이 올바르지 않습니다.',
+} as const;
+
 function parseShuffleLettersPayload(
   detail: unknown
 ): ShuffleLettersPayload | null {
@@ -114,17 +119,22 @@ function ShuffleLettersDemo({
 
   const handleSubmit = (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
-    const started = startAnimation({ text, iterations, fps });
+    const payload = parseShuffleLettersPayload({ text, iterations, fps });
+    const started = payload ? startAnimation(payload) : false;
     const nativeEvent = e.nativeEvent as AgentSubmitEvent;
 
     if (nativeEvent.agentInvoked && nativeEvent.respondWith) {
       nativeEvent.respondWith(
-        Promise.resolve({
-          ok: started,
-          text,
-          iterations,
-          fps,
-        })
+        Promise.resolve(
+          payload
+            ? {
+                ok: started,
+                text: payload.text,
+                iterations: payload.iterations,
+                fps: payload.fps,
+              }
+            : invalidPayloadResponse
+        )
       );
     }
   };

--- a/src/mdx/components/shuffle-letters-demo/shuffle-letters-demo.tsx
+++ b/src/mdx/components/shuffle-letters-demo/shuffle-letters-demo.tsx
@@ -27,6 +27,38 @@ type AgentSubmitEvent = SubmitEvent & {
   respondWith?: (promise: Promise<unknown>) => void;
 };
 
+function parseShuffleLettersPayload(
+  detail: unknown
+): ShuffleLettersPayload | null {
+  if (typeof detail !== 'object' || detail === null) return null;
+
+  const { text, iterations, fps } = detail as Partial<
+    Record<keyof ShuffleLettersPayload, unknown>
+  >;
+
+  if (typeof text !== 'string' || text.trim() === '') return null;
+  if (
+    typeof iterations !== 'number' ||
+    !Number.isFinite(iterations) ||
+    !Number.isInteger(iterations) ||
+    iterations < 1 ||
+    iterations > 50
+  ) {
+    return null;
+  }
+  if (
+    typeof fps !== 'number' ||
+    !Number.isFinite(fps) ||
+    !Number.isInteger(fps) ||
+    fps < 1 ||
+    fps > 60
+  ) {
+    return null;
+  }
+
+  return { text, iterations, fps };
+}
+
 function ShuffleLettersDemo({
   initialText = '한글 English 123 @#$%',
   initialIterations = 15,
@@ -38,21 +70,20 @@ function ShuffleLettersDemo({
   const [isAnimating, setIsAnimating] = useState(false);
   const animatedTextRef = useRef<HTMLDivElement>(null);
   const clearAnimationRef = useRef<(() => void) | null>(null);
+  const intendedDisplayTextRef = useRef(initialText);
 
   const stopAnimation = useCallback(() => {
     if (clearAnimationRef.current) {
       clearAnimationRef.current();
-      (
-        clearAnimationRef as React.MutableRefObject<(() => void) | null>
-      ).current = null;
+      clearAnimationRef.current = null;
       setIsAnimating(false);
 
       // 즉시 텍스트를 원래 상태로 되돌립니다.
       if (animatedTextRef.current) {
-        animatedTextRef.current.textContent = text;
+        animatedTextRef.current.textContent = intendedDisplayTextRef.current;
       }
     }
-  }, [text]);
+  }, []);
 
   const startAnimation = useCallback(
     ({
@@ -60,8 +91,9 @@ function ShuffleLettersDemo({
       iterations: nextIterations,
       fps: nextFps,
     }: ShuffleLettersPayload) => {
-      if (isAnimating || !animatedTextRef.current) return false;
+      if (clearAnimationRef.current || !animatedTextRef.current) return false;
 
+      intendedDisplayTextRef.current = nextText;
       setText(nextText);
       setIterations(nextIterations);
       setFps(nextFps);
@@ -78,7 +110,7 @@ function ShuffleLettersDemo({
 
       return true;
     },
-    [isAnimating]
+    []
   );
 
   const handleSubmit = (e: React.FormEvent<HTMLFormElement>) => {
@@ -111,9 +143,10 @@ function ShuffleLettersDemo({
 
   useEffect(() => {
     const handleRun = (event: Event) => {
-      const { detail } = event as CustomEvent<ShuffleLettersPayload>;
-      if (!detail) return;
-      startAnimation(detail);
+      const { detail } = event as CustomEvent<unknown>;
+      const payload = parseShuffleLettersPayload(detail);
+      if (!payload) return;
+      startAnimation(payload);
     };
 
     const handleStop = () => {

--- a/src/mdx/components/shuffle-letters-demo/shuffle-letters-demo.tsx
+++ b/src/mdx/components/shuffle-letters-demo/shuffle-letters-demo.tsx
@@ -16,6 +16,17 @@ const ShuffleLettersDemoSchema = z.object({
 
 type ShuffleLettersDemoProps = z.infer<typeof ShuffleLettersDemoSchema>;
 
+type ShuffleLettersPayload = {
+  text: string;
+  iterations: number;
+  fps: number;
+};
+
+type AgentSubmitEvent = SubmitEvent & {
+  agentInvoked?: boolean;
+  respondWith?: (promise: Promise<unknown>) => void;
+};
+
 function ShuffleLettersDemo({
   initialText = '한글 English 123 @#$%',
   initialIterations = 15,
@@ -43,19 +54,48 @@ function ShuffleLettersDemo({
     }
   }, [text]);
 
+  const startAnimation = useCallback(
+    ({
+      text: nextText,
+      iterations: nextIterations,
+      fps: nextFps,
+    }: ShuffleLettersPayload) => {
+      if (isAnimating || !animatedTextRef.current) return false;
+
+      setText(nextText);
+      setIterations(nextIterations);
+      setFps(nextFps);
+      animatedTextRef.current.textContent = nextText;
+      setIsAnimating(true);
+      clearAnimationRef.current = shuffleLetters(animatedTextRef.current, {
+        iterations: nextIterations,
+        fps: nextFps,
+        onComplete: () => {
+          setIsAnimating(false);
+          clearAnimationRef.current = null;
+        },
+      });
+
+      return true;
+    },
+    [isAnimating]
+  );
+
   const handleSubmit = (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
-    if (isAnimating) return;
+    const started = startAnimation({ text, iterations, fps });
+    const nativeEvent = e.nativeEvent as AgentSubmitEvent;
 
-    setIsAnimating(true);
-    clearAnimationRef.current = shuffleLetters(animatedTextRef.current!, {
-      iterations,
-      fps,
-      onComplete: () => {
-        setIsAnimating(false);
-        clearAnimationRef.current = null;
-      },
-    });
+    if (nativeEvent.agentInvoked && nativeEvent.respondWith) {
+      nativeEvent.respondWith(
+        Promise.resolve({
+          ok: started,
+          text,
+          iterations,
+          fps,
+        })
+      );
+    }
   };
 
   useEffect(() => {
@@ -69,6 +109,26 @@ function ShuffleLettersDemo({
     return () => window.removeEventListener('keydown', handleKeyDown);
   }, [isAnimating, stopAnimation]);
 
+  useEffect(() => {
+    const handleRun = (event: Event) => {
+      const { detail } = event as CustomEvent<ShuffleLettersPayload>;
+      if (!detail) return;
+      startAnimation(detail);
+    };
+
+    const handleStop = () => {
+      stopAnimation();
+    };
+
+    window.addEventListener('webmcp:run-shuffle-letters', handleRun);
+    window.addEventListener('webmcp:stop-shuffle-letters', handleStop);
+
+    return () => {
+      window.removeEventListener('webmcp:run-shuffle-letters', handleRun);
+      window.removeEventListener('webmcp:stop-shuffle-letters', handleStop);
+    };
+  }, [startAnimation, stopAnimation]);
+
   const isValid =
     text &&
     text.trim() !== '' &&
@@ -80,30 +140,31 @@ function ShuffleLettersDemo({
   return (
     <div className="mt-6 flex flex-col items-center gap-4 rounded-lg border border-gray-200 bg-secondary p-6">
       <div className="mb-4 text-center">
-        <h3 className="mb-2 text-xl font-bold">
-          Shuffle Letters Playground
-        </h3>
+        <h3 className="mb-2 text-xl font-bold">Shuffle Letters Playground</h3>
         <p className="text-sm text-secondary-foreground dark:text-secondary-foreground">
           `iterations`와 `fps` 값을 조정하여 애니메이션 효과를 실험해보세요
         </p>
       </div>
 
       <form
+        aria-label="Shuffle letters playground"
+        toolname="run_shuffle_letters"
+        tooldescription="Runs the shuffle letters animation with visible form values."
+        toolautosubmit=""
         onSubmit={handleSubmit}
         className="w-full max-w-md space-y-4"
       >
         <div>
-          <label
-            htmlFor="text"
-            className="mb-2 block text-sm font-medium"
-          >
+          <label htmlFor="text" className="mb-2 block text-sm font-medium">
             텍스트
           </label>
           <Input
             id="text"
+            name="text"
             type="text"
             value={text || ''}
             onChange={e => setText(e.target.value)}
+            toolparamdescription="Text to animate with the shuffle letters effect."
             required
           />
         </div>
@@ -118,28 +179,29 @@ function ShuffleLettersDemo({
             </label>
             <Input
               id="iterations"
+              name="iterations"
               type="number"
               value={iterations}
               onChange={e => setIterations(Number(e.target.value))}
               min="1"
               max="50"
+              toolparamdescription="Number of random character replacements per letter. Use 1 through 50."
               required
             />
           </div>
           <div className="flex-1">
-            <label
-              htmlFor="fps"
-              className="mb-2 block text-sm font-medium"
-            >
+            <label htmlFor="fps" className="mb-2 block text-sm font-medium">
               fps (1-60)
             </label>
             <Input
               id="fps"
+              name="fps"
               type="number"
               value={fps}
               onChange={e => setFps(Number(e.target.value))}
               min="1"
               max="60"
+              toolparamdescription="Animation frames per second. Use 1 through 60."
               required
             />
           </div>
@@ -155,9 +217,7 @@ function ShuffleLettersDemo({
       </form>
 
       <div className="w-full max-w-md rounded-lg border border-gray-200 bg-white p-4 dark:border-gray-600 dark:bg-gray-800">
-        <h4 className="mb-3 text-center text-lg font-semibold">
-          결과
-        </h4>
+        <h4 className="mb-3 text-center text-lg font-semibold">결과</h4>
         <div
           ref={animatedTextRef}
           className="min-h-8 py-2 text-center text-lg font-medium"


### PR DESCRIPTION
## Summary

- Add production-gated WebMCP support that activates only when `navigator.modelContext` exists.
- Register route-relevant tools during idle with abort cleanup and declarative-form duplicate filtering.
- Add lazy content metadata index API, document snapshot markers, tool handlers, shuffle letters WebMCP integration, permissions policy, focus styles, and docs.

## Verification

- `pnpm test:unit --run src/components/webmcp/lib/register-tool.spec.ts src/components/webmcp/lib/content-index.spec.ts src/app/api/webmcp/content-index/route.spec.ts src/components/webmcp/lib/content-snapshot.spec.ts src/components/webmcp/model/tool-handlers.spec.ts src/components/webmcp/ui/webmcp-provider.spec.tsx src/mdx/components/shuffle-letters-demo/shuffle-letters-demo.spec.tsx` — passed, 51 tests
- `pnpm test:unit --run src/components/sound/ui/sound-switcher.spec.tsx src/components/series/test/series-navigation-top.spec.tsx src/components/series/test/series-navigation-bottom.spec.tsx src/mdx/mdx.spec.ts` — passed, 61 tests
- `pnpm check-types` — passed
- changed-file Prettier checks — passed
- targeted ESLint on changed source files — 0 errors; one pre-existing Tailwind migration warning in `src/app/layout.tsx`
- `pnpm build` with network access — passed; `/api/webmcp/content-index` builds as a static route
- Fresh code review via `superpowers:requesting-code-review` — ready to merge after fixes

## Notes

- Full `pnpm lint` is blocked in this nested worktree by duplicate parent/current Next ESLint plugin config: `@next/next` conflict between `.eslintrc.json` and `../../.eslintrc.json`.
- No unresolved safety boundary remains; docs and permissions policy are updated.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 브라우저 기능 감지 기반 클라이언트 전용 WebMCP 활성화(문서 내 도구: 내부 탐색·콘텐츠 검색·헤딩 점프·코드 복사·셔플 등)
  * 셔플 레터스 플레이그라운드에 외부 이벤트로 시작/중지 및 에이전트 응답 지원
  * MDX 콘텐츠에 메타데이터 노출 및 테마·사운드 제어·현재 URL 복사 개선

* **Documentation**
  * WebMCP 아키텍처·설계·컨벤션·구현 계획 문서화 및 가이드 보강

* **Tests**
  * WebMCP 동작, 콘텐츠 인덱스/스냅샷, 툴 핸들러, 플레이그라운드 연동 등 테스트 추가/확장

* **Chores**
  * 권한 정책에 tools=(self) 추가, 개발 설정·무시 목록 업데이트 (워크트리 무시)

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jaem1n207/bendd/pull/112?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->