### PR TITLE
fix: 스크롤·셔플 애니메이션 프레임 저하 개선

### DIFF
--- a/src/components/article/lib/shuffle-letters.ts
+++ b/src/components/article/lib/shuffle-letters.ts
@@ -95,14 +95,7 @@ export function shuffleLetters(
 
   element.textContent = '';
 
-  let timeout: NodeJS.Timeout | null = null;
-
-  const shuffle = (start: number): void => {
-    if (start > charsPositions.length) {
-      options.onComplete(element);
-      return;
-    }
-
+  const renderStep = (start: number): void => {
     const shuffledChars = [...charsArray];
     for (let i = Math.max(start, 0); i < charsPositions.length; i++) {
       if (i < start + options.iterations) {
@@ -118,13 +111,42 @@ export function shuffleLetters(
     }
 
     element.textContent = shuffledChars.join('');
-
-    timeout = setTimeout(() => shuffle(start + 1), 1000 / options.fps);
   };
 
-  shuffle(-options.iterations);
+  // setTimeout 체인 대신 rAF 사용: 여러 요소가 동시에 셔플돼도 DOM 변경이
+  // 프레임 경계에 정렬되고, 탭이 백그라운드로 가면 자동으로 일시 정지된다
+  const stepDuration = 1000 / options.fps;
+  let step = -options.iterations;
+  let lastStepTime: number | null = null;
+  let rafId: number | null = null;
+
+  const tick = (now: number): void => {
+    if (lastStepTime === null) lastStepTime = now;
+
+    const elapsed = now - lastStepTime;
+    if (elapsed >= stepDuration) {
+      // 프레임 드랍으로 누락된 step은 건너뛰어 전체 길이를 일정하게 유지
+      step = Math.min(
+        step + Math.floor(elapsed / stepDuration),
+        charsPositions.length
+      );
+      lastStepTime = now - (elapsed % stepDuration);
+      renderStep(step);
+
+      // 마지막 step은 원본 텍스트 전체를 복원한다
+      if (step >= charsPositions.length) {
+        options.onComplete(element);
+        return;
+      }
+    }
+
+    rafId = requestAnimationFrame(tick);
+  };
+
+  renderStep(step);
+  rafId = requestAnimationFrame(tick);
 
   return () => {
-    if (timeout) clearTimeout(timeout);
+    if (rafId !== null) cancelAnimationFrame(rafId);
   };
 }

--- a/src/components/article/lib/shuffle-letters.ts
+++ b/src/components/article/lib/shuffle-letters.ts
@@ -65,11 +65,16 @@ export function shuffleLetters(
     ...config,
   };
 
-  if (options.iterations < 1 || options.iterations > 50) {
+  // NaN/Infinity가 통과하면 stepDuration이 NaN이 되어 rAF 루프가 종료되지 않는다
+  if (
+    !Number.isFinite(options.iterations) ||
+    options.iterations < 1 ||
+    options.iterations > 50
+  ) {
     throw new RangeError('iterations는 1 이상 50 이하의 값이어야 합니다.');
   }
 
-  if (options.fps < 1 || options.fps > 60) {
+  if (!Number.isFinite(options.fps) || options.fps < 1 || options.fps > 60) {
     throw new RangeError('fps는 1 이상 60 이하의 값이어야 합니다.');
   }
 

--- a/src/components/article/test/shuffle-letters.spec.ts
+++ b/src/components/article/test/shuffle-letters.spec.ts
@@ -1,6 +1,27 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { shuffleLetters } from '../lib/shuffle-letters';
 
+const MAX_FRAMES = 1000;
+const FRAME_DURATION = 16;
+
+// rAF를 수동 제어해 프레임 단위로 결정적으로 진행시킨다
+let pendingFrames: Map<number, FrameRequestCallback>;
+let nextRafId: number;
+let frameTime: number;
+
+function advanceFrame() {
+  frameTime += FRAME_DURATION;
+  const frames = [...pendingFrames.values()];
+  pendingFrames.clear();
+  frames.forEach(callback => callback(frameTime));
+}
+
+function advanceFramesUntil(predicate: () => boolean) {
+  for (let frame = 0; frame < MAX_FRAMES && !predicate(); frame++) {
+    advanceFrame();
+  }
+}
+
 describe('shuffleLetters', () => {
   let element: HTMLElement;
 
@@ -8,9 +29,22 @@ describe('shuffleLetters', () => {
     element = document.createElement('div');
     element.textContent = 'Test content';
     document.body.appendChild(element);
+
+    pendingFrames = new Map();
+    nextRafId = 0;
+    frameTime = 0;
+    vi.spyOn(window, 'requestAnimationFrame').mockImplementation(callback => {
+      nextRafId += 1;
+      pendingFrames.set(nextRafId, callback);
+      return nextRafId;
+    });
+    vi.spyOn(window, 'cancelAnimationFrame').mockImplementation(id => {
+      pendingFrames.delete(id);
+    });
   });
 
   afterEach(() => {
+    vi.restoreAllMocks();
     document.body.removeChild(element);
   });
 
@@ -34,23 +68,36 @@ describe('shuffleLetters', () => {
   });
 
   it('should call the onComplete callback', () => {
-    const onComplete = vi.fn(() => {
-      expect(onComplete).toHaveBeenCalled();
-    });
+    const onComplete = vi.fn();
     shuffleLetters(element, { onComplete });
+
+    advanceFramesUntil(() => onComplete.mock.calls.length > 0);
+
+    expect(onComplete).toHaveBeenCalledTimes(1);
+    expect(onComplete).toHaveBeenCalledWith(element);
   });
 
   it('the final text content of the element should be the same as in the beginning', () => {
     const initialText = element.textContent;
-    const onComplete = () => {
-      expect(element.textContent).toBe(initialText);
-    };
-    shuffleLetters(element, { onComplete, iterations: 1, fps: 1 });
+    const onComplete = vi.fn();
+    shuffleLetters(element, { onComplete, iterations: 1, fps: 30 });
+
+    advanceFramesUntil(() => onComplete.mock.calls.length > 0);
+
+    expect(onComplete).toHaveBeenCalled();
+    expect(element.textContent).toBe(initialText);
   });
 
   it('should cleanup when called', () => {
-    const clearShuffleLetters = shuffleLetters(element);
+    const onComplete = vi.fn();
+    const clearShuffleLetters = shuffleLetters(element, { onComplete });
     expect(typeof clearShuffleLetters).toBe('function');
+
     clearShuffleLetters();
+    for (let frame = 0; frame < 100; frame++) {
+      advanceFrame();
+    }
+
+    expect(onComplete).not.toHaveBeenCalled();
   });
 });

--- a/src/components/article/test/shuffle-letters.spec.ts
+++ b/src/components/article/test/shuffle-letters.spec.ts
@@ -62,6 +62,17 @@ describe('shuffleLetters', () => {
     expect(() => shuffleLetters(element, { fps: 61 })).toThrow(RangeError);
   });
 
+  it('should throw error if iterations or fps is not a finite number', () => {
+    // NaN이 통과하면 stepDuration 비교가 항상 false가 되어 rAF 루프가 끝나지 않는다
+    expect(() => shuffleLetters(element, { iterations: NaN })).toThrow(
+      RangeError
+    );
+    expect(() => shuffleLetters(element, { fps: NaN })).toThrow(RangeError);
+    expect(() => shuffleLetters(element, { fps: Infinity })).toThrow(
+      RangeError
+    );
+  });
+
   it('should throw error if first argument is not HTMLElement', () => {
     const invalidElement = 'h1' as unknown as HTMLElement; // 잘못된 타입의 요소
     expect(() => shuffleLetters(invalidElement)).toThrow(TypeError);

--- a/src/components/article/ui/article-item.tsx
+++ b/src/components/article/ui/article-item.tsx
@@ -28,47 +28,53 @@ export function ArticleItem({
   const [publishedAtRef, animatePublishedAt] = useAnimate();
 
   useEffect(() => {
-    if (isInView) {
-      const delay = index * 0.15;
-      const duration = 1;
+    if (!isInView) return;
 
-      animateName(nameRef.current, { opacity: [0, 1] }, { duration, delay });
-      if (nameRef.current) {
+    const delay = index * 0.15;
+    const duration = 1;
+    // 언마운트 후에도 셔플 애니메이션이 분리된 DOM을 계속 변경하지 않도록 정리
+    const cancelShuffles: Array<() => void> = [];
+
+    animateName(nameRef.current, { opacity: [0, 1] }, { duration, delay });
+    if (nameRef.current) {
+      cancelShuffles.push(
         shuffleLetters(nameRef.current, {
           iterations: 10,
-        });
-      }
-
-      animateSummary(
-        summaryRef.current,
-        { opacity: [0, 1] },
-        { duration, delay }
+        })
       );
-      if (summaryRef.current) {
+    }
+
+    animateSummary(summaryRef.current, { opacity: [0, 1] }, { duration, delay });
+    if (summaryRef.current) {
+      cancelShuffles.push(
         shuffleLetters(summaryRef.current, {
           iterations: 15,
-        });
-      }
-
-      animateLine(
-        lineRef.current,
-        { scaleX: [0, 1], opacity: [1, 0.5] },
-        {
-          duration,
-          delay,
-          type: 'spring',
-        }
+        })
       );
-
-      animatePublishedAt(
-        publishedAtRef.current,
-        { opacity: [0, 1] },
-        { duration, delay }
-      );
-      if (publishedAtRef.current) {
-        shuffleLetters(publishedAtRef.current);
-      }
     }
+
+    animateLine(
+      lineRef.current,
+      { scaleX: [0, 1], opacity: [1, 0.5] },
+      {
+        duration,
+        delay,
+        type: 'spring',
+      }
+    );
+
+    animatePublishedAt(
+      publishedAtRef.current,
+      { opacity: [0, 1] },
+      { duration, delay }
+    );
+    if (publishedAtRef.current) {
+      cancelShuffles.push(shuffleLetters(publishedAtRef.current));
+    }
+
+    return () => {
+      cancelShuffles.forEach(cancel => cancel());
+    };
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [isInView]);
 

--- a/src/mdx/common/table-of-contents/use-toc.ts
+++ b/src/mdx/common/table-of-contents/use-toc.ts
@@ -173,9 +173,11 @@ export function useActiveAnchor(
       }
 
       // 뷰포트 상단으로부터 마지막 헤더를 찾아 활성화
+      // getScrollOffset은 querySelector + getBoundingClientRect를 수행하므로 루프 밖에서 1회만 측정
+      const scrollOffset = getScrollOffset();
       let activeLink: string | null = null;
       for (const { link, top } of headers) {
-        if (top > scrollY + getScrollOffset()) {
+        if (top > scrollY + scrollOffset) {
           break;
         }
         activeLink = link;


### PR DESCRIPTION
## 요약

프론트엔드에서 프레임 저하를 일으키는 패턴을 점검하고 두 가지 핫스팟을 수정합니다.

### 1. TOC 스크롤 핸들러 — 루프 내 반복 DOM 측정 제거 (`use-toc.ts`)

`setActiveLink`의 헤더 순회 루프 안에서 `getScrollOffset()`이 **매 반복마다** `document.querySelector('nav.toc-navbar')` + `getBoundingClientRect()`를 호출하고 있었습니다. 스크롤 중 100ms마다 실행되는 경로이므로, 루프 불변값을 루프 밖에서 1회만 측정하도록 호이스팅했습니다. 활성 앵커 판정 로직은 동일합니다.

### 2. 셔플 애니메이션 — setTimeout 체인 → rAF 타임스텝 (`shuffle-letters.ts`)

기존 구현은 요소당 `setTimeout(1000/fps)` 체인으로 textContent를 변경했습니다. 글 목록(`/article`)에서는 아이템당 3개(제목·요약·날짜)씩 N개 아이템이 동시에 돌면서 프레임 경계와 무관한 타이머 수십 개가 각자 DOM을 변경 → 한 프레임에 몰리거나 프레임 사이에 끼며 잔상/프레임 드랍의 원인이 됐습니다.

`requestAnimationFrame` 기반 타임스텝으로 전환해:

- DOM 변경이 프레임 경계에 정렬되고 프레임당 최대 1회만 발생
- 백그라운드 탭에서 자동 일시 정지 (setTimeout은 계속 돌았음)
- 프레임 드랍 시 누락된 step을 건너뛰어 전체 재생 길이 일정 유지

공개 계약(`shuffleLetters(el, config) => cancel`, `onComplete`)은 그대로라 shuffle-letters-demo, playground, WebMCP 이벤트 핸들러에 영향이 없습니다.

### 3. ArticleItem — 셔플 정리 누수 수정 (`article-item.tsx`)

`shuffleLetters`가 반환하는 cancel 함수를 버리고 있어, 애니메이션 중 라우트를 이동하면 타이머 체인이 **분리된 DOM 노드를 계속 변경**했습니다. cancel을 보관했다가 effect cleanup에서 호출합니다.

### 4. (리뷰 반영) fps/iterations 비유한 숫자 검증

CodeRabbit 지적 반영: NaN이 범위 비교를 통과하면 rAF 루프가 종료되지 않는 경로를 `Number.isFinite` 검증으로 차단하고 회귀 테스트를 추가했습니다.

### 테스트

- 기존 `shuffle-letters.spec.ts`의 `onComplete` 단언은 테스트 종료 후 실행되어 실제 검증이 안 되던 형태 → rAF 수동 모킹으로 프레임 단위 결정적 검증으로 보강 (vitest 1.6에는 `vi.advanceTimersToNextFrame`이 없어 수동 모킹 사용)
- cancel 후 프레임이 더 진행돼도 `onComplete`가 호출되지 않는 회귀 테스트 추가
- NaN/Infinity 입력이 RangeError를 던지는 회귀 테스트 추가

## 검증

- `pnpm check-types` ✅
- `pnpm test:unit` ✅ 232/232 (+ 신규 테스트)
- `pnpm lint` ✅ (변경 파일 신규 경고 없음)
- `pnpm build` ✅

## 점검했지만 변경하지 않은 것

- 독 네비게이션 mousemove: motion value 기반이라 리렌더 없음 (이상 없음)
- 이미지 줌 rAF 추적 루프: 닫기 transition 동안만 동작, 400ms 안전장치 존재 (이상 없음)
- `BrowserDetector`의 `next/server` 클라이언트 import: 프레임이 아닌 번들 사이즈 관심사라 별도 작업으로 분리

🤖 Generated with [Claude Code](https://claude.com/claude-code)