### PR TITLE
fix(browser-detector): next/server 의존 제거하고 경량 UA 파싱으로 교체

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -24,7 +24,7 @@ const Signature = dynamic(
 
 const BrowserDetector = dynamic(
   () =>
-    import('../components/browser-detector').then(mod => mod.BrowserDetector),
+    import('@/components/browser-detector').then(mod => mod.BrowserDetector),
   {
     ssr: false,
   }

--- a/src/components/browser-detector.spec.tsx
+++ b/src/components/browser-detector.spec.tsx
@@ -1,0 +1,134 @@
+import { render } from '@testing-library/react';
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { BrowserDetector, getBrowserClassName } from './browser-detector';
+
+const UA = {
+  chromeWindows:
+    'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/125.0.0.0 Safari/537.36',
+  chromeAndroid:
+    'Mozilla/5.0 (Linux; Android 14; Pixel 8) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/125.0.0.0 Mobile Safari/537.36',
+  chromeIOS:
+    'Mozilla/5.0 (iPhone; CPU iPhone OS 17_4 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) CriOS/125.0.6422.51 Mobile/15E148 Safari/604.1',
+  whaleMac:
+    'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/124.0.0.0 Whale/3.26.244.21 Safari/537.36',
+  whaleAndroid:
+    'Mozilla/5.0 (Linux; Android 14; SM-S918N) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/124.0.0.0 Whale/3.0.1.2 Mobile Safari/537.36',
+  edgeWindows:
+    'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/125.0.0.0 Safari/537.36 Edg/125.0.0.0',
+  edgeAndroid:
+    'Mozilla/5.0 (Linux; Android 14; Pixel 8) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/124.0.0.0 Mobile Safari/537.36 EdgA/124.0.2478.104',
+  edgeIOS:
+    'Mozilla/5.0 (iPhone; CPU iPhone OS 17_4 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) EdgiOS/124.2478.89 Version/17.0 Mobile/15E148 Safari/604.1',
+  operaWindows:
+    'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/124.0.0.0 Safari/537.36 OPR/110.0.0.0',
+  operaAndroid:
+    'Mozilla/5.0 (Linux; Android 14; Pixel 8) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/123.0.0.0 Mobile Safari/537.36 OPR/76.2.4027.73374',
+  vivaldiLinux:
+    'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/124.0.0.0 Safari/537.36 Vivaldi/6.7.3329.31',
+  vivaldiAndroid:
+    'Mozilla/5.0 (Linux; Android 14; Pixel 8) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/124.0.0.0 Mobile Safari/537.36 Vivaldi/6.7.3335.89',
+  firefoxWindows:
+    'Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:126.0) Gecko/20100101 Firefox/126.0',
+  firefoxAndroid:
+    'Mozilla/5.0 (Android 14; Mobile; rv:126.0) Gecko/126.0 Firefox/126.0',
+  firefoxIOS:
+    'Mozilla/5.0 (iPhone; CPU iPhone OS 17_4 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) FxiOS/126.0 Mobile/15E148 Safari/605.1.15',
+  safariMac:
+    'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.4.1 Safari/605.1.15',
+  safariIOS:
+    'Mozilla/5.0 (iPhone; CPU iPhone OS 17_4_1 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.4.1 Mobile/15E148 Safari/604.1',
+} as const;
+
+describe('getBrowserClassName — 데스크톱', () => {
+  it.each([
+    ['Chrome (Windows)', UA.chromeWindows, 'browser-chrome'],
+    ['Whale (Mac)', UA.whaleMac, 'browser-whale'],
+    ['Edge (Windows)', UA.edgeWindows, 'browser-edge'],
+    ['Opera (Windows)', UA.operaWindows, 'browser-opera'],
+    ['Vivaldi (Linux)', UA.vivaldiLinux, 'browser-vivaldi'],
+    ['Firefox (Windows)', UA.firefoxWindows, 'browser-firefox'],
+    ['Safari (Mac)', UA.safariMac, 'browser-safari'],
+  ])('%s → %s', (_label, ua, expected) => {
+    expect(getBrowserClassName(ua)).toBe(expected);
+  });
+});
+
+describe('getBrowserClassName — 모바일', () => {
+  it.each([
+    ['Chrome (Android)', UA.chromeAndroid, 'browser-mobile-chrome'],
+    ['Chrome (iOS, CriOS)', UA.chromeIOS, 'browser-mobile-chrome'],
+    ['Whale (Android)', UA.whaleAndroid, 'browser-mobile-whale'],
+    ['Edge (Android, EdgA)', UA.edgeAndroid, 'browser-mobile-edge'],
+    ['Edge (iOS, EdgiOS)', UA.edgeIOS, 'browser-mobile-edge'],
+    ['Opera (Android, OPR)', UA.operaAndroid, 'browser-mobile-opera'],
+    ['Vivaldi (Android)', UA.vivaldiAndroid, 'browser-mobile-vivaldi'],
+    ['Firefox (Android)', UA.firefoxAndroid, 'browser-mobile-firefox'],
+    ['Firefox (iOS, FxiOS)', UA.firefoxIOS, 'browser-mobile-firefox'],
+    ['Safari (iOS)', UA.safariIOS, 'browser-mobile-safari'],
+  ])('%s → %s', (_label, ua, expected) => {
+    expect(getBrowserClassName(ua)).toBe(expected);
+  });
+});
+
+describe('getBrowserClassName — 감지 순서', () => {
+  it('Whale UA는 Chrome/Safari 토큰을 포함해도 whale로 매칭된다', () => {
+    expect(UA.whaleMac).toContain('Chrome/');
+    expect(UA.whaleMac).toContain('Safari/');
+    expect(getBrowserClassName(UA.whaleMac)).toBe('browser-whale');
+  });
+
+  it('Edge/Opera/Vivaldi UA는 Chrome 토큰을 포함해도 자기 이름으로 매칭된다', () => {
+    expect(getBrowserClassName(UA.edgeWindows)).toBe('browser-edge');
+    expect(getBrowserClassName(UA.operaWindows)).toBe('browser-opera');
+    expect(getBrowserClassName(UA.vivaldiLinux)).toBe('browser-vivaldi');
+  });
+
+  it('Safari는 Chrome 계열 UA에 매칭되지 않고 순수 WebKit UA에만 매칭된다', () => {
+    expect(getBrowserClassName(UA.chromeWindows)).not.toBe('browser-safari');
+    expect(getBrowserClassName(UA.safariMac)).toBe('browser-safari');
+  });
+});
+
+describe('getBrowserClassName — 미지원 UA', () => {
+  it('Samsung Internet은 Chrome 토큰을 포함하지만 null을 반환한다', () => {
+    const samsungUA =
+      'Mozilla/5.0 (Linux; Android 14; SM-S918N) AppleWebKit/537.36 (KHTML, like Gecko) SamsungBrowser/25.0 Chrome/121.0.0.0 Mobile Safari/537.36';
+    expect(getBrowserClassName(samsungUA)).toBeNull();
+  });
+
+  it('브라우저가 아닌 UA는 null을 반환한다', () => {
+    expect(getBrowserClassName('curl/8.4.0')).toBeNull();
+    expect(getBrowserClassName('')).toBeNull();
+  });
+});
+
+describe('BrowserDetector 컴포넌트', () => {
+  const originalUserAgent = window.navigator.userAgent;
+
+  function setUserAgent(ua: string) {
+    Object.defineProperty(window.navigator, 'userAgent', {
+      value: ua,
+      configurable: true,
+    });
+  }
+
+  afterEach(() => {
+    setUserAgent(originalUserAgent);
+    document.documentElement.className = '';
+  });
+
+  it('navigator.userAgent 기반 클래스를 documentElement에 추가한다', () => {
+    setUserAgent(UA.safariIOS);
+    render(<BrowserDetector />);
+    expect(
+      document.documentElement.classList.contains('browser-mobile-safari')
+    ).toBe(true);
+  });
+
+  it('감지 실패 시 클래스를 추가하지 않는다', () => {
+    setUserAgent('curl/8.4.0');
+    render(<BrowserDetector />);
+    expect(document.documentElement.className).toBe('');
+  });
+});

--- a/src/components/browser-detector.tsx
+++ b/src/components/browser-detector.tsx
@@ -1,14 +1,53 @@
 'use client';
 
-import { NextRequest, userAgent } from 'next/server';
 import { useLayoutEffect } from 'react';
+
+type BrowserName =
+  | 'chrome'
+  | 'edge'
+  | 'firefox'
+  | 'opera'
+  | 'safari'
+  | 'vivaldi'
+  | 'whale';
+
+// 매칭 순서가 곧 우선순위다. Whale/Edge/Opera/Vivaldi는 UA에 Chrome 토큰을
+// 포함하는 Chromium 파생이므로 Chrome보다 먼저, Safari는 대부분의 WebKit UA에
+// 포함되므로 마지막에 검사한다. iOS는 CriOS(Chrome)/FxiOS(Firefox)/EdgiOS(Edge)/
+// OPiOS(Opera) 토큰을 사용한다.
+const BROWSER_MATCHERS: ReadonlyArray<readonly [BrowserName, RegExp]> = [
+  ['whale', /\bwhale\//i],
+  ['edge', /\bedg(?:e|a|ios)?\//i],
+  ['opera', /\bopr\/|\bopios\/|\bopera\b/i],
+  ['vivaldi', /\bvivaldi\//i],
+  ['chrome', /\b(?:chrome|crios|crmo)\//i],
+  ['firefox', /\b(?:firefox|fxios)\//i],
+  ['safari', /\bsafari\//i],
+];
+
+/**
+ * ua-parser-js의 browser.name을 lowercase + 공백→하이픈 변환한 결과와
+ * 호환되는 클래스 이름을 반환한다. 예: "Mobile Safari" → browser-mobile-safari
+ * globals.css에 정의된 browser-{name} / browser-mobile-{name} 셀렉터와 짝을 이룬다.
+ */
+export function getBrowserClassName(ua: string): string | null {
+  // Samsung Internet은 UA에 Chrome 토큰을 포함하지만 별도 브라우저다.
+  // 전용 스프라이트가 없으므로 기본 아이콘으로 폴백시킨다.
+  if (/\bsamsungbrowser\//i.test(ua)) return null;
+
+  const matched = BROWSER_MATCHERS.find(([, pattern]) => pattern.test(ua));
+  if (!matched) return null;
+
+  const isMobile = /mobi/i.test(ua);
+  return `browser-${isMobile ? 'mobile-' : ''}${matched[0]}`;
+}
 
 export function BrowserDetector() {
   useLayoutEffect(() => {
-    const request = new NextRequest(window.location.href);
-    const ua = userAgent(request);
-    const browserName = ua.browser.name?.toLowerCase().replace(/\s+/g, '-');
-    document.documentElement.classList.add(`browser-${browserName}`);
+    const className = getBrowserClassName(navigator.userAgent);
+    if (className) {
+      document.documentElement.classList.add(className);
+    }
   }, []);
 
   return null;


### PR DESCRIPTION
## 요약

`'use client'` 컴포넌트인 `BrowserDetector`가 `next/server`의 `NextRequest` + `userAgent`를 임포트하면서 내부 의존성인 **ua-parser-js가 클라이언트 lazy chunk에 통째로 포함**되던 문제를 수정합니다. 목적은 `document.documentElement`에 `browser-<name>` 클래스 하나를 추가하는 것뿐이므로, `navigator.userAgent`를 직접 파싱하는 경량 감지 로직으로 교체했습니다.

## 번들 크기 변화

| 항목 | 변경 전 | 변경 후 |
| --- | --- | --- |
| ua-parser-js 포함 lazy chunk (`292-*.js`) | 59.4 KB (raw) | **제거됨** |
| shared First Load JS | 87.6 KB | **87.4 KB** |
| `/` First Load JS | 87.7 KB | 87.6 KB |

빌드 후 `.next/static/chunks`에서 `UAParser` 문자열 검색 결과 0건 — 의존성이 완전히 제거되었습니다. 새 감지 로직은 layout 청크에 인라인되어 추가 네트워크 요청도 사라졌습니다.

## 동작 호환성

ua-parser-js의 `browser.name`을 lowercase + 공백→하이픈 변환한 기존 클래스 산출 규칙과 호환됩니다 (예: "Mobile Safari" → `browser-mobile-safari`). `globals.css`에서 실제 사용 중인 14종 클래스(`browser-{chrome,whale,firefox,safari,edge,opera,vivaldi}` + `mobile-` 변형)가 동일하게 산출되며, CSS에서 `browser-X`/`browser-mobile-X` 쌍은 항상 같은 스프라이트 규칙으로 묶여 있어 시각적 결과도 동일합니다.

**감지 순서 (배열 순서 = 우선순위):**

1. Whale → 2. Edge (`Edg`/`EdgA`/`EdgiOS`/legacy `Edge`) → 3. Opera (`OPR`/`OPiOS`/legacy `Opera`) → 4. Vivaldi → 5. Chrome (`CriOS`/`CrMo` 포함) → 6. Firefox (`FxiOS` 포함) → 7. Safari

Chromium 파생 브라우저는 UA에 `Chrome` 토큰을 포함하므로 Chrome보다 먼저 검사하고, Safari는 Chrome 계열이 아닐 때만 매칭됩니다. Samsung Internet은 `Chrome` 토큰을 포함하지만 전용 스프라이트가 없으므로 `null`을 반환해 기본 아이콘으로 폴백합니다 (기존 동작과 동일).

## 테스트

- 유닛 테스트 24건 추가 (`browser-detector.spec.tsx`): 데스크톱 7종 / 모바일 10종 UA 매트릭스, 감지 순서 검증, Samsung Internet·비브라우저 UA 처리, 컴포넌트 마운트 시 documentElement 클래스 부착
- 전체 유닛 테스트 256건 통과, `pnpm check-types` / `pnpm lint` 통과, 프로덕션 빌드 성공

## 기타

- `layout.tsx`의 browser-detector import를 상대 경로에서 `@/` alias로 수정 (P5)

🤖 Generated with [Claude Code](https://claude.com/claude-code)