### PR TITLE
docs(workflow): PR 머지 명령을 rebase로 수정

### DIFF
--- a/.cursor/rules/global.mdc
+++ b/.cursor/rules/global.mdc
@@ -27,7 +27,7 @@ See [AGENTS.md](../../AGENTS.md) for the full canonical reference and [docs/](..
    - `gh pr create --assignee jaem1n207` (correct)
 
 6. **PR 후 브랜치 정리**: PR 병합 후 반드시 원격/로컬 브랜치를 삭제
-   - `gh pr merge --squash --delete-branch` → `git checkout main && git pull origin main`
+   - `gh pr merge --rebase --delete-branch` → `git checkout main && git pull origin main`
 
 ## Content System
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -67,7 +67,7 @@ claude  # Anthropic Claude Code CLI로 독립 인스턴스 실행
 6. 피드백 반영 → 재커밋 → push → 모든 리뷰 코멘트에 응답
 7. PR 설명 최신화: `gh pr edit <pr_number> --body "<업데이트된 설명>"`
 8. CI 통과 확인: `gh pr checks <pr_number>`
-9. LGTM 코멘트 추가 → `gh pr merge <pr_number> --squash --delete-branch`
+9. LGTM 코멘트 추가 → `gh pr merge <pr_number> --rebase --delete-branch` (저장소 설정상 squash 머지 비활성)
 10. 로컬 정리: `git checkout main && git pull origin main`
 
 ### 브랜치 네이밍


### PR DESCRIPTION
## 요약

CLAUDE.md의 PR 생명주기 9단계와 `.cursor/rules/global.mdc`의 브랜치 정리 규칙에 적힌 머지 명령을 `--squash`에서 `--rebase`로 수정한다.

## 배경

이 저장소는 GitHub 설정에서 squash 머지가 비활성화되어 있어 `gh pr merge --squash`가 다음 에러로 실패한다:

> Squash merges are not allowed on this repository

실제로 PR #109, #114 모두 rebase로 병합되었다. 문서가 실제 저장소 설정과 불일치하여 에이전트가 머지 단계에서 반복적으로 실패하던 문제를 바로잡는다.

## 변경 사항

- `CLAUDE.md` PR 생명주기 9단계: `--squash` → `--rebase` (squash 비활성 사유 주석 추가)
- `.cursor/rules/global.mdc` Critical Rules 6번: `--squash` → `--rebase`

🤖 Generated with [Claude Code](https://claude.com/claude-code)