### PR TITLE
fix(article): 목록 재방문 시 입장 애니메이션 생략

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -5,7 +5,7 @@ import dynamic from 'next/dynamic';
 import { Fira_Mono as FontMono, Inter as FontSans } from 'next/font/google';
 import type { WebSite, WithContext } from 'schema-dts';
 
-import { Navigation } from '@/components/navigation';
+import { Navigation, PathnameHistoryTracker } from '@/components/navigation';
 import { ThemeProvider } from '@/components/theme';
 import { Toaster } from '@/components/ui/sonner';
 import { TooltipProvider } from '@/components/ui/tooltip';
@@ -130,6 +130,7 @@ export default function RootLayout({
           }}
         />
         <BrowserDetector />
+        <PathnameHistoryTracker />
         <ThemeProvider
           attribute="class"
           defaultTheme="system"

--- a/src/components/article/lib/entrance-animation.ts
+++ b/src/components/article/lib/entrance-animation.ts
@@ -1,22 +1,23 @@
+import { getPreviousPathname } from '@/components/navigation';
+
 /**
- * 목록 입장 애니메이션(stagger + 셔플)을 경로별로 한 번만 재생하기 위한 기록.
+ * 목록 입장 애니메이션(stagger + 셔플)은 "섹션에 들어왔다"는 신호이므로
+ * 직전 경로가 해당 목록의 하위 경로(글 상세, 시리즈 등)일 때만 생략한다.
+ * 글을 읽고 뒤로 가기로 돌아온 직후에는 목록을 즉시 훑어볼 수 있어야 하고,
+ * 다른 섹션에서 넘어올 때(/article ↔ /craft)는 다시 재생한다.
  *
- * 모듈 스코프 상태를 의도적으로 사용한다:
- * - SPA 클라이언트 네비게이션(뒤로 가기 포함)에서는 모듈이 유지되므로
- *   재방문 시 애니메이션을 생략해 목록을 즉시 훑어볼 수 있다.
- * - 새로고침이나 직접 진입 시에는 모듈이 초기화되어 애니메이션이 다시 재생된다.
- * - 서버에서는 effect가 실행되지 않아 기록이 비어 있으므로
- *   SSR 결과는 항상 "애니메이션 재생" 상태와 일치한다 (hydration mismatch 없음).
- *
- * sessionStorage를 쓰지 않는 이유: 탭 세션 전체에서 효과가 사라지는 데다,
- * 첫 로드 hydration 시점에 서버 HTML과 클라이언트 판정이 어긋날 수 있다.
+ * 경로 기록(pathname-history)은 SPA 네비게이션에서만 유지되므로
+ * 새로고침이나 직접 진입 시에는 항상 재생되고, hydration이 일어나는 최초
+ * 로드에서는 기록이 비어 있어 SSR 결과(재생 상태)와 어긋나지 않는다.
  */
-const playedPathnames = new Set<string>();
+export function shouldPlayEntranceAnimation(listPathname: string): boolean {
+  const previous = getPreviousPathname(listPathname);
+  if (!previous) return true;
 
-export function shouldPlayEntranceAnimation(pathname: string): boolean {
-  return !playedPathnames.has(pathname);
-}
-
-export function markEntranceAnimationPlayed(pathname: string): void {
-  playedPathnames.add(pathname);
+  // '/article-foo'처럼 접두사만 같은 형제 경로를 하위 경로로 오인하지 않도록
+  // 경계 문자('/')까지 포함해 비교한다
+  const childPrefix = listPathname.endsWith('/')
+    ? listPathname
+    : `${listPathname}/`;
+  return !previous.startsWith(childPrefix);
 }

--- a/src/components/article/lib/entrance-animation.ts
+++ b/src/components/article/lib/entrance-animation.ts
@@ -1,0 +1,22 @@
+/**
+ * 목록 입장 애니메이션(stagger + 셔플)을 경로별로 한 번만 재생하기 위한 기록.
+ *
+ * 모듈 스코프 상태를 의도적으로 사용한다:
+ * - SPA 클라이언트 네비게이션(뒤로 가기 포함)에서는 모듈이 유지되므로
+ *   재방문 시 애니메이션을 생략해 목록을 즉시 훑어볼 수 있다.
+ * - 새로고침이나 직접 진입 시에는 모듈이 초기화되어 애니메이션이 다시 재생된다.
+ * - 서버에서는 effect가 실행되지 않아 기록이 비어 있으므로
+ *   SSR 결과는 항상 "애니메이션 재생" 상태와 일치한다 (hydration mismatch 없음).
+ *
+ * sessionStorage를 쓰지 않는 이유: 탭 세션 전체에서 효과가 사라지는 데다,
+ * 첫 로드 hydration 시점에 서버 HTML과 클라이언트 판정이 어긋날 수 있다.
+ */
+const playedPathnames = new Set<string>();
+
+export function shouldPlayEntranceAnimation(pathname: string): boolean {
+  return !playedPathnames.has(pathname);
+}
+
+export function markEntranceAnimationPlayed(pathname: string): void {
+  playedPathnames.add(pathname);
+}

--- a/src/components/article/test/entrance-animation.spec.ts
+++ b/src/components/article/test/entrance-animation.spec.ts
@@ -1,0 +1,47 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+// 모듈 스코프 Set이 테스트 간에 공유되지 않도록 매번 새로 로드한다
+async function loadFreshModule() {
+  vi.resetModules();
+  return import('../lib/entrance-animation');
+}
+
+describe('entrance-animation', () => {
+  beforeEach(() => {
+    vi.resetModules();
+  });
+
+  it('처음 방문한 경로는 애니메이션을 재생한다', async () => {
+    const { shouldPlayEntranceAnimation } = await loadFreshModule();
+
+    expect(shouldPlayEntranceAnimation('/article')).toBe(true);
+  });
+
+  it('재생 기록이 있는 경로는 애니메이션을 생략한다', async () => {
+    const { shouldPlayEntranceAnimation, markEntranceAnimationPlayed } =
+      await loadFreshModule();
+
+    markEntranceAnimationPlayed('/article');
+
+    expect(shouldPlayEntranceAnimation('/article')).toBe(false);
+  });
+
+  it('경로별로 독립적으로 기록한다', async () => {
+    const { shouldPlayEntranceAnimation, markEntranceAnimationPlayed } =
+      await loadFreshModule();
+
+    markEntranceAnimationPlayed('/article');
+
+    expect(shouldPlayEntranceAnimation('/craft')).toBe(true);
+  });
+
+  it('같은 경로를 여러 번 기록해도 생략 판정이 유지된다', async () => {
+    const { shouldPlayEntranceAnimation, markEntranceAnimationPlayed } =
+      await loadFreshModule();
+
+    markEntranceAnimationPlayed('/craft');
+    markEntranceAnimationPlayed('/craft');
+
+    expect(shouldPlayEntranceAnimation('/craft')).toBe(false);
+  });
+});

--- a/src/components/article/test/entrance-animation.spec.ts
+++ b/src/components/article/test/entrance-animation.spec.ts
@@ -1,47 +1,52 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-// 모듈 스코프 Set이 테스트 간에 공유되지 않도록 매번 새로 로드한다
-async function loadFreshModule() {
-  vi.resetModules();
-  return import('../lib/entrance-animation');
-}
+import { getPreviousPathname } from '@/components/navigation';
+import { shouldPlayEntranceAnimation } from '../lib/entrance-animation';
 
-describe('entrance-animation', () => {
+vi.mock('@/components/navigation', () => ({
+  getPreviousPathname: vi.fn(),
+}));
+
+const mockGetPreviousPathname = vi.mocked(getPreviousPathname);
+
+describe('shouldPlayEntranceAnimation', () => {
   beforeEach(() => {
-    vi.resetModules();
+    mockGetPreviousPathname.mockReset();
   });
 
-  it('처음 방문한 경로는 애니메이션을 재생한다', async () => {
-    const { shouldPlayEntranceAnimation } = await loadFreshModule();
+  it('직전 경로가 없으면(새로고침·직접 진입) 재생한다', () => {
+    mockGetPreviousPathname.mockReturnValue(null);
 
     expect(shouldPlayEntranceAnimation('/article')).toBe(true);
   });
 
-  it('재생 기록이 있는 경로는 애니메이션을 생략한다', async () => {
-    const { shouldPlayEntranceAnimation, markEntranceAnimationPlayed } =
-      await loadFreshModule();
-
-    markEntranceAnimationPlayed('/article');
+  it('글 상세에서 목록으로 돌아오면 생략한다', () => {
+    mockGetPreviousPathname.mockReturnValue('/article/some-post');
 
     expect(shouldPlayEntranceAnimation('/article')).toBe(false);
   });
 
-  it('경로별로 독립적으로 기록한다', async () => {
-    const { shouldPlayEntranceAnimation, markEntranceAnimationPlayed } =
-      await loadFreshModule();
+  it('시리즈 등 더 깊은 하위 경로에서 돌아와도 생략한다', () => {
+    mockGetPreviousPathname.mockReturnValue('/article/series/frontend');
 
-    markEntranceAnimationPlayed('/article');
-
-    expect(shouldPlayEntranceAnimation('/craft')).toBe(true);
+    expect(shouldPlayEntranceAnimation('/article')).toBe(false);
   });
 
-  it('같은 경로를 여러 번 기록해도 생략 판정이 유지된다', async () => {
-    const { shouldPlayEntranceAnimation, markEntranceAnimationPlayed } =
-      await loadFreshModule();
+  it('다른 섹션에서 넘어오면 재생한다', () => {
+    mockGetPreviousPathname.mockReturnValue('/craft');
 
-    markEntranceAnimationPlayed('/craft');
-    markEntranceAnimationPlayed('/craft');
+    expect(shouldPlayEntranceAnimation('/article')).toBe(true);
+  });
 
-    expect(shouldPlayEntranceAnimation('/craft')).toBe(false);
+  it('다른 섹션의 상세에서 넘어와도 재생한다', () => {
+    mockGetPreviousPathname.mockReturnValue('/craft/some-work');
+
+    expect(shouldPlayEntranceAnimation('/article')).toBe(true);
+  });
+
+  it('접두사만 같은 형제 경로는 하위 경로로 오인하지 않는다', () => {
+    mockGetPreviousPathname.mockReturnValue('/article-archive');
+
+    expect(shouldPlayEntranceAnimation('/article')).toBe(true);
   });
 });

--- a/src/components/article/ui/article-item.tsx
+++ b/src/components/article/ui/article-item.tsx
@@ -2,8 +2,13 @@
 
 import { motion, useAnimate, useInView } from 'framer-motion';
 import Link from 'next/link';
-import { useEffect, useRef } from 'react';
+import { usePathname } from 'next/navigation';
+import { useEffect, useRef, useState } from 'react';
 
+import {
+  markEntranceAnimationPlayed,
+  shouldPlayEntranceAnimation,
+} from '@/components/article/lib/entrance-animation';
 import { shuffleLetters } from '@/components/article/lib/shuffle-letters';
 import { WithSound } from '@/components/sound';
 import { cn } from '@/lib/utils';
@@ -20,6 +25,9 @@ export function ArticleItem({
   series,
   index,
 }: ArticleInfo & { index: number }) {
+  const pathname = usePathname();
+  // 마운트 시점에 한 번만 판정 — 이후 다른 아이템이 기록을 추가해도 영향받지 않는다
+  const [shouldAnimate] = useState(() => shouldPlayEntranceAnimation(pathname));
   const itemRef = useRef<HTMLAnchorElement>(null);
   const isInView = useInView(itemRef, { once: true, margin: '-100px 0px' });
   const [nameRef, animateName] = useAnimate();
@@ -28,7 +36,11 @@ export function ArticleItem({
   const [publishedAtRef, animatePublishedAt] = useAnimate();
 
   useEffect(() => {
-    if (!isInView) return;
+    markEntranceAnimationPlayed(pathname);
+  }, [pathname]);
+
+  useEffect(() => {
+    if (!shouldAnimate || !isInView) return;
 
     const delay = index * 0.15;
     const duration = 1;
@@ -76,7 +88,7 @@ export function ArticleItem({
       cancelShuffles.forEach(cancel => cancel());
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [isInView]);
+  }, [isInView, shouldAnimate]);
 
   return (
     <WithSound assetPath="/sounds/stapling.mp3">
@@ -86,7 +98,7 @@ export function ArticleItem({
         className={cn(
           'relative block w-[calc(100%+1rem)] overflow-hidden rounded-xl px-3 py-4 hover:bg-gray-300 sm:flex sm:items-center sm:gap-3'
         )}
-        initial={{ opacity: 0 }}
+        initial={shouldAnimate ? { opacity: 0 } : false}
         animate={{ opacity: 1 }}
       >
         <motion.h2

--- a/src/components/article/ui/article-item.tsx
+++ b/src/components/article/ui/article-item.tsx
@@ -5,10 +5,7 @@ import Link from 'next/link';
 import { usePathname } from 'next/navigation';
 import { useEffect, useRef, useState } from 'react';
 
-import {
-  markEntranceAnimationPlayed,
-  shouldPlayEntranceAnimation,
-} from '@/components/article/lib/entrance-animation';
+import { shouldPlayEntranceAnimation } from '@/components/article/lib/entrance-animation';
 import { shuffleLetters } from '@/components/article/lib/shuffle-letters';
 import { WithSound } from '@/components/sound';
 import { cn } from '@/lib/utils';
@@ -26,7 +23,7 @@ export function ArticleItem({
   index,
 }: ArticleInfo & { index: number }) {
   const pathname = usePathname();
-  // 마운트 시점에 한 번만 판정 — 이후 다른 아이템이 기록을 추가해도 영향받지 않는다
+  // 마운트 시점에 한 번만 판정 — 이후 경로 기록이 갱신돼도 영향받지 않는다
   const [shouldAnimate] = useState(() => shouldPlayEntranceAnimation(pathname));
   const itemRef = useRef<HTMLAnchorElement>(null);
   const isInView = useInView(itemRef, { once: true, margin: '-100px 0px' });
@@ -34,10 +31,6 @@ export function ArticleItem({
   const [summaryRef, animateSummary] = useAnimate();
   const [lineRef, animateLine] = useAnimate();
   const [publishedAtRef, animatePublishedAt] = useAnimate();
-
-  useEffect(() => {
-    markEntranceAnimationPlayed(pathname);
-  }, [pathname]);
 
   useEffect(() => {
     if (!shouldAnimate || !isInView) return;

--- a/src/components/navigation/index.ts
+++ b/src/components/navigation/index.ts
@@ -1,1 +1,3 @@
+export { getPreviousPathname } from './model/pathname-history';
 export { Navigation } from './ui/navigation';
+export { PathnameHistoryTracker } from './ui/pathname-history-tracker';

--- a/src/components/navigation/model/pathname-history.ts
+++ b/src/components/navigation/model/pathname-history.ts
@@ -1,0 +1,27 @@
+/**
+ * SPA 클라이언트 네비게이션의 직전 경로를 추적하는 모듈 상태.
+ *
+ * 모듈 스코프를 의도적으로 사용한다: 클라이언트 네비게이션(뒤로 가기 포함)
+ * 에서는 유지되고, 새로고침이나 직접 진입 시에는 초기화된다. 서버에서는
+ * effect가 실행되지 않아 기록이 항상 비어 있으므로 SSR 결과에 영향이 없다.
+ */
+let lastPathname: string | null = null;
+let previousPathname: string | null = null;
+
+export function recordPathname(pathname: string): void {
+  // StrictMode 재실행 등으로 같은 경로가 중복 기록되면 직전 경로가 유실된다
+  if (pathname === lastPathname) return;
+  previousPathname = lastPathname;
+  lastPathname = pathname;
+}
+
+/**
+ * `current` 기준의 직전 경로를 반환한다.
+ *
+ * 레이아웃의 추적 effect가 새 경로를 먼저 기록한 뒤 페이지 컴포넌트가
+ * 늦게 마운트되는 스트리밍 시나리오가 있어, 이미 기록된 현재 경로는
+ * 건너뛰고 그 이전 경로를 돌려준다.
+ */
+export function getPreviousPathname(current: string): string | null {
+  return lastPathname === current ? previousPathname : lastPathname;
+}

--- a/src/components/navigation/test/pathname-history.spec.ts
+++ b/src/components/navigation/test/pathname-history.spec.ts
@@ -1,0 +1,56 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+// 모듈 스코프 상태가 테스트 간에 공유되지 않도록 매번 새로 로드한다
+async function loadFreshModule() {
+  vi.resetModules();
+  return import('../model/pathname-history');
+}
+
+describe('pathname-history', () => {
+  beforeEach(() => {
+    vi.resetModules();
+  });
+
+  it('기록이 없으면 null을 반환한다', async () => {
+    const { getPreviousPathname } = await loadFreshModule();
+
+    expect(getPreviousPathname('/article')).toBe(null);
+  });
+
+  it('아직 기록되지 않은 현재 경로 기준으로 마지막 기록을 반환한다', async () => {
+    const { getPreviousPathname, recordPathname } = await loadFreshModule();
+
+    recordPathname('/article/some-post');
+
+    expect(getPreviousPathname('/article')).toBe('/article/some-post');
+  });
+
+  it('현재 경로가 이미 기록됐으면 그 이전 경로를 반환한다', async () => {
+    const { getPreviousPathname, recordPathname } = await loadFreshModule();
+
+    recordPathname('/article/some-post');
+    recordPathname('/article');
+
+    expect(getPreviousPathname('/article')).toBe('/article/some-post');
+  });
+
+  it('같은 경로가 중복 기록돼도 직전 경로를 유지한다', async () => {
+    const { getPreviousPathname, recordPathname } = await loadFreshModule();
+
+    recordPathname('/article/some-post');
+    recordPathname('/article');
+    recordPathname('/article');
+
+    expect(getPreviousPathname('/article')).toBe('/article/some-post');
+  });
+
+  it('경로 이동을 따라 직전 경로가 갱신된다', async () => {
+    const { getPreviousPathname, recordPathname } = await loadFreshModule();
+
+    recordPathname('/article');
+    recordPathname('/craft');
+    recordPathname('/article');
+
+    expect(getPreviousPathname('/article')).toBe('/craft');
+  });
+});

--- a/src/components/navigation/ui/pathname-history-tracker.tsx
+++ b/src/components/navigation/ui/pathname-history-tracker.tsx
@@ -1,0 +1,21 @@
+'use client';
+
+import { usePathname } from 'next/navigation';
+import { useEffect } from 'react';
+
+import { recordPathname } from '../model/pathname-history';
+
+/**
+ * 루트 레이아웃에 마운트되어 모든 경로 변경을 기록하는 null 컴포넌트.
+ * 페이지 컴포넌트는 render 단계에서 기록을 읽고, 기록 갱신은 effect
+ * 단계에서 일어나므로 같은 커밋 안에서는 항상 "이전" 경로가 보인다.
+ */
+export function PathnameHistoryTracker() {
+  const pathname = usePathname();
+
+  useEffect(() => {
+    recordPathname(pathname);
+  }, [pathname]);
+
+  return null;
+}


### PR DESCRIPTION
## 문제

`/article`, `/craft` 목록 페이지의 입장 애니메이션(아이템별 0.15초 stagger + 글자 셔플)이 페이지가 마운트될 때마다 재생됩니다. 글 상세 페이지에서 뒤로 가기로 목록에 돌아오면 매번 애니메이션이 다시 실행되어 목록을 즉시 훑어볼 수 없습니다. 특히 스크롤 복원 위치가 목록 하단이면 `index * 0.15초` 지연 때문에 수 초간 빈 화면을 보게 됩니다.

## 해결 규칙

입장 애니메이션은 "섹션에 들어왔다"는 신호로 취급합니다. **직전 경로가 현재 목록의 하위 경로일 때만 생략**합니다.

| 시나리오 | 동작 |
| --- | --- |
| 새로고침 · 직접 진입 | 재생 |
| `/article/[slug]` → 뒤로 가기 → `/article` | **생략** (즉시 표시) |
| `/article/series/[id]` → `/article` | **생략** |
| `/article` ↔ `/craft` 번갈아 방문 | 재생 |
| `/craft/[slug]` → `/article` (다른 섹션 상세에서 이동) | 재생 |

## 구현

- `src/components/navigation/model/pathname-history.ts` (신규): 직전 pathname을 모듈 스코프로 추적. 같은 경로 중복 기록 무시(StrictMode 안전), 스트리밍으로 현재 경로가 먼저 기록되는 경우 처리
- `src/components/navigation/ui/pathname-history-tracker.tsx` (신규): 루트 레이아웃에 마운트되는 null 컴포넌트. 페이지는 render 단계에서 기록을 읽고 갱신은 effect 단계에서 일어나 같은 커밋 안에서 항상 "이전" 경로가 보장됨
- `src/components/article/lib/entrance-animation.ts` (신규): 하위 경로 판정 (`/article-foo` 같은 형제 경로 오인 방지)
- `src/components/article/ui/article-item.tsx`: 마운트 시 `useState` lazy initializer로 한 번만 판정, 생략 시 stagger·셔플·페이드 전부 건너뛰고 `initial={false}`로 즉시 표시
- `src/app/layout.tsx`: 추적 컴포넌트 마운트 (1줄)

### 모듈 상태를 쓴 이유 (sessionStorage 대비)

- hydration이 일어나는 최초 로드에서는 기록이 항상 비어 있어 SSR 결과(재생 상태)와 구조적으로 일치 — hydration mismatch 불가능
- 새로고침 시 초기화되어 첫인상 효과 유지
- 저장소 I/O 없음 — 성능·보안 영향 없음

## 검증

- `pnpm check-types` ✅
- `pnpm lint` ✅ (경고는 기존 파일의 것만)
- `pnpm vitest run` ✅ 268/268 (신규 11개 포함)
- `pnpm build` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)