### PR TITLE
fix(layout): craft 목록과 TOC 간격 정리

### DIFF
--- a/src/app/craft/page.tsx
+++ b/src/app/craft/page.tsx
@@ -47,9 +47,9 @@ export default function CraftPage() {
   const collectionJsonLd = createCraftIndexGraph({ articles });
 
   return (
-    <main className="relative mx-auto my-0 min-h-screen max-w-4xl overflow-y-auto px-6 pt-10 sm:py-32">
+    <main>
       <JsonLdScript data={collectionJsonLd} />
-      <div className="mt-8 flex flex-col gap-7">
+      <div className="relative mx-auto my-0 mt-8 max-w-4xl space-y-1 overflow-y-auto overflow-x-hidden px-2 pb-28 pt-10 sm:px-6 sm:py-32">
         <SeriesBanner items={seriesSummaries} />
         {formattedArticleInfo.map((article, index) => (
           <ArticleItem key={article.href} {...article} index={index} />

--- a/src/mdx/common/table-of-contents/table-of-contents.tsx
+++ b/src/mdx/common/table-of-contents/table-of-contents.tsx
@@ -24,7 +24,7 @@ export function TableOfContents() {
   }, []);
 
   return (
-    <nav className="toc-navbar flex min-h-0 min-w-0 flex-1 flex-col">
+    <nav className="toc-navbar flex max-h-full min-h-0 min-w-0 flex-col self-start overflow-hidden">
       <div
         ref={markerRef}
         className={cn(

--- a/tests/article-list-spacing.spec.ts
+++ b/tests/article-list-spacing.spec.ts
@@ -1,0 +1,32 @@
+import { expect, type Page, test } from '@playwright/test';
+
+async function getFirstItemGap(page: Page) {
+  const items = page.locator(
+    [
+      'main a[href^="/article/"]:not([href^="/article/series/"])',
+      'main a[href^="/craft/"]:not([href^="/craft/series/"])',
+    ].join(', ')
+  );
+  await expect(items.nth(1)).toBeVisible();
+
+  return items.evaluateAll(([first, second]) => {
+    const firstRect = first.getBoundingClientRect();
+    const secondRect = second.getBoundingClientRect();
+
+    return Math.round(secondRect.top - firstRect.bottom);
+  });
+}
+
+test('craft list uses the same item spacing as article list', async ({
+  page,
+}) => {
+  await page.setViewportSize({ width: 1280, height: 800 });
+
+  await page.goto('/article');
+  const articleGap = await getFirstItemGap(page);
+
+  await page.goto('/craft');
+  const craftGap = await getFirstItemGap(page);
+
+  expect(craftGap).toBe(articleGap);
+});

--- a/tests/toc-sidebar.spec.ts
+++ b/tests/toc-sidebar.spec.ts
@@ -62,6 +62,39 @@ test.describe('Table of Contents sidebar', () => {
       viewportHeight - bottom16InPx + 1
     );
   });
+
+  test('should size the TOC border to the rendered list', async ({ page }) => {
+    await page.setViewportSize({ width: 1280, height: 800 });
+
+    const tocNav = page.locator('nav.toc-navbar');
+    await expect(tocNav).toBeVisible();
+    await page.locator('nav.toc-navbar ul a').first().waitFor();
+
+    const containerBox = await page
+      .locator('.fixed.bottom-16.left-5.top-24')
+      .boundingBox();
+    const tocMetrics = await tocNav.evaluate(nav => {
+      const list = nav.querySelector('ul');
+      if (!list) {
+        throw new Error('TOC list is missing');
+      }
+
+      const navRect = nav.getBoundingClientRect();
+      const listRect = list.getBoundingClientRect();
+
+      return {
+        listBottom: listRect.bottom,
+        navBottom: navRect.bottom,
+        navHeight: navRect.height,
+      };
+    });
+
+    expect(containerBox).not.toBeNull();
+    expect(tocMetrics.navHeight).toBeLessThan(containerBox!.height);
+    expect(Math.abs(tocMetrics.navBottom - tocMetrics.listBottom)).toBeLessThan(
+      2
+    );
+  });
 });
 
 test.describe('TOC highlight after page refresh', () => {
@@ -93,7 +126,22 @@ test.describe('TOC highlight after page refresh', () => {
     await page.reload();
     await page.locator('nav.toc-navbar ul a').first().waitFor();
 
-    const scrollPositions = [300, 600, 1200, 1800];
+    const scrollPositions = await page
+      .locator('nav.toc-navbar ul a')
+      .evaluateAll(links =>
+        links.slice(0, 4).map(link => {
+          const hash = link.getAttribute('href');
+          const id = hash ? decodeURIComponent(hash.slice(1)) : '';
+          const heading = document.getElementById(id);
+          const navbar = document.querySelector('nav.toc-navbar');
+          const scrollOffset = (navbar?.getBoundingClientRect().top ?? 0) + 8;
+          const headingTop =
+            (heading?.getBoundingClientRect().top ?? 0) + window.scrollY;
+
+          return Math.max(1, headingTop - scrollOffset + 1);
+        })
+      );
+
     for (const pos of scrollPositions) {
       await page.evaluate(y => window.scrollTo(0, y), pos);
 


### PR DESCRIPTION
## 변경 사항

- `/craft` 글 목록 wrapper를 `/article` 목록과 같은 spacing/padding contract로 맞췄습니다.
- TOC `nav`가 sidebar 전체 높이를 채우지 않도록 조정해 왼쪽 선이 렌더링된 목록 높이에 맞게 끝나도록 했습니다.
- `/article`과 `/craft` item gap 비교 E2E, TOC border 높이 E2E를 추가했습니다.
- 기존 TOC highlight E2E는 고정 픽셀 대신 실제 heading 위치 기준으로 스크롤하도록 정리했습니다.

## 검증

- `pnpm check-types`
- `pnpm build`
- `pnpm test:e2e tests/article-list-spacing.spec.ts tests/toc-sidebar.spec.ts --project=chromium`