### PR TITLE
fix(mdx): MagicMove SCSS 문법 지원

### DIFF
--- a/src/mdx/components/magic-move/use-highlighter.spec.tsx
+++ b/src/mdx/components/magic-move/use-highlighter.spec.tsx
@@ -1,0 +1,16 @@
+import { renderHook, waitFor } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+
+import { useHighlighter } from '@/mdx/components/magic-move/use-highlighter';
+
+describe('useHighlighter', () => {
+  it('MagicMove에서 사용하는 SCSS 문법을 등록한다', async () => {
+    const { result } = renderHook(() => useHighlighter());
+
+    await waitFor(() => {
+      expect(result.current).toBeDefined();
+    });
+
+    expect(result.current?.getLoadedLanguages()).toContain('scss');
+  });
+});

--- a/src/mdx/components/magic-move/use-highlighter.ts
+++ b/src/mdx/components/magic-move/use-highlighter.ts
@@ -21,6 +21,7 @@ export function useHighlighter(): HighlighterCore | undefined {
           import('shiki/langs/javascript.mjs'),
           import('shiki/langs/html.mjs'),
           import('shiki/langs/css.mjs'),
+          import('shiki/langs/scss.mjs'),
           import('shiki/langs/json.mjs'),
           import('shiki/langs/shell.mjs'),
           import('shiki/langs/markdown.mjs'),


### PR DESCRIPTION
## 변경 내용

- `MagicMove` 전용 Shiki highlighter에 SCSS grammar를 등록했습니다.
- 실제 highlighter의 로드 언어 목록에 `scss`가 포함되는지 검증하는 회귀 테스트를 추가했습니다.

## 원인

`naming-tokens-in-design` 글은 `<MagicMove lang="scss">`를 사용하지만, `useHighlighter`는 CSS까지만 등록하고 SCSS grammar는 로드하지 않았습니다. 이 불일치 때문에 클라이언트 렌더링 중 `Language 'scss' not found` 예외가 발생하며 페이지 전체 오류 경계가 표시됐습니다.

## 검증

- `pnpm test:unit --run src/mdx/components/magic-move/use-highlighter.spec.tsx`
- `pnpm check-types`
- `pnpm lint --file src/mdx/components/magic-move/use-highlighter.ts --file src/mdx/components/magic-move/use-highlighter.spec.tsx`
- `pnpm build`

프로덕션 빌드는 문제 경로 `/article/naming-tokens-in-design`를 포함한 정적 페이지 31개 생성을 완료했습니다. lint에는 기존 저장소 경고만 있으며 신규 오류는 없습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **새 기능**
  - SCSS 코드 블록의 구문 강조를 지원합니다.

- **테스트**
  - 하이라이터 초기화 후 SCSS 언어가 정상적으로 등록되는지 검증하는 테스트를 추가했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->